### PR TITLE
[41] feat(api): add basic path param support

### DIFF
--- a/packages/api/gulpfile.js
+++ b/packages/api/gulpfile.js
@@ -28,8 +28,7 @@ gulp.task("clean", function() {
 });
 gulp.task("build", gulp.series("clean", function() {
 
-  var tsResult = tsProject
-  .src()
+  var tsResult = gulp.src(paths.src.scripts.all)
   .pipe(sourcemaps.init())
   .pipe(tsProject());
 

--- a/packages/api/jest.config.js
+++ b/packages/api/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   "testEnvironment": "node",
   "transform": {
-    "^.+\\.tsx?$": "ts-jest"
+    "^.+\\.ts?$": "ts-jest"
   },
   "testRegex": "src/.*?\.spec\.ts$",
   "moduleFileExtensions": [

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "jest",
     "start": "node dist/app.js",
-    "build": "gulp build"
+    "build": "gulp build",
+    "lint": "tslint --fix --project tsconfig.json"
   },
   "author": "Collin Driscoll",
   "license": "UNLICENSED",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -12,7 +12,7 @@
   "license": "UNLICENSED",
   "devDependencies": {
     "@types/glob": "^5.0.35",
-    "@types/jest": "^23.3.2",
+    "@types/jest": "^23.3.3",
     "@types/koa": "^2.0.46",
     "@types/koa-route": "^3.2.4",
     "@types/request-promise": "^4.1.42",

--- a/packages/api/src/config/KoaConfiguration.ts
+++ b/packages/api/src/config/KoaConfiguration.ts
@@ -1,4 +1,4 @@
-import { AwilixContainer, asClass, asValue } from "awilix";
+import { asClass, asValue, AwilixContainer } from "awilix";
 import * as Koa from "koa";
 import { Connection } from "typeorm";
 import { RestRepository } from "../controllers/RestRepository";

--- a/packages/api/src/config/KoaConfiguration.ts
+++ b/packages/api/src/config/KoaConfiguration.ts
@@ -1,4 +1,4 @@
-import { AwilixContainer } from "awilix";
+import { AwilixContainer, asClass, asValue } from "awilix";
 import * as Koa from "koa";
 import { Connection } from "typeorm";
 import { RestRepository } from "../controllers/RestRepository";
@@ -29,10 +29,11 @@ export class KoaConfiguration {
   }
   configure() {
     const handlers = this.routeComponentProcessor.getRouteHandlerMap();
-    const routerMiddleware = new RouterMiddlewareFactory(
-      handlers,
-      this.container
-    ).create();
+    const configContainer = this.container.createScope();
+    configContainer.register("handlers", asValue(handlers));
+    const routerMiddleware = configContainer
+      .build(asClass(RouterMiddlewareFactory))
+      .create();
     const rendererMiddleware = new RenderMiddlewareFactory().create();
     this.webserver.use(routerMiddleware);
     this.webserver.use(rendererMiddleware);

--- a/packages/api/src/config/RouteTransformationService.spec.ts
+++ b/packages/api/src/config/RouteTransformationService.spec.ts
@@ -1,0 +1,24 @@
+import { RouteTransformationService } from "./RouteTransformationService";
+
+describe("service:RouteTransformationService", () => {
+  const tests = [
+    ["/{a}/{b}", "/foo/bar", { a: "foo", b: "bar" }],
+    ["/user/{id}", "/foo/bar", undefined],
+    ["/step/{step}", "/step/123", { step: "123" }]
+  ];
+  const spec = (
+    routeDefinition: string,
+    requestPath: string,
+    expectedVariables: { [variable: string]: string }
+  ) => {
+    it("properly parses" + routeDefinition, () => {
+      const svc = new RouteTransformationService();
+      const parsedRoute = svc.parseRoute(routeDefinition);
+      const pathVariables = svc.getPathVariables(parsedRoute, requestPath);
+      expect(pathVariables).toEqual(expectedVariables);
+    });
+  };
+  for (const args of tests) {
+    (spec as any)(...args);
+  }
+});

--- a/packages/api/src/config/RouteTransformationService.ts
+++ b/packages/api/src/config/RouteTransformationService.ts
@@ -1,0 +1,92 @@
+import { Component } from "../reflection/Component";
+
+interface IParsedRoute {
+  pattern: RegExp;
+  routeParams: string[];
+}
+
+/**
+ * Class which defines behavior for matching request url's to registered routes.
+ */
+@Component()
+export class RouteTransformationService {
+  /**
+   * Extract metadata from a path registration.
+   * @param path - The path to parse.
+   * @return An object with a pattern and route params list.
+   */
+  parseRoute(path: string): IParsedRoute {
+    const pattern = this.getRouteRegex(path);
+    const routeParams = this.getRouteParams(path);
+    return {
+      pattern,
+      routeParams
+    };
+  }
+
+  /**
+   * Get a map of populated path variables for the specified route & request path.
+   * @param route - The route to populate.
+   * @param path - The request path to pull params from.
+   * @return An object mapping path param names to string values. Returns void if
+   *    the route did not match this path.
+   */
+  getPathVariables(
+    route: IParsedRoute,
+    requestPath: string
+  ): { [param: string]: string } {
+    const { routeParams, pattern } = route;
+    const result: { [param: string]: string } = {};
+
+    const regexResult = pattern.exec(requestPath);
+    if (!regexResult) {
+      return undefined;
+    }
+
+    let index = 0;
+    for (const routeParam of routeParams) {
+      result[routeParam] = regexResult[index + 1];
+      index++;
+    }
+    return result;
+  }
+
+  /**
+   * Get the ordered list of route params from a path.
+   * eg: /foo/{id} => ["id"]
+   * @param path - The path to parse for route params.
+   */
+  protected getRouteParams(path: string): string[] {
+    const parts = path.split(/\{|\}/g);
+    const routeParams: string[] = [];
+
+    for (let i = 0; i < parts.length; i++) {
+      if (i % 2 === 0) {
+        continue;
+      }
+      routeParams.push(parts[i]);
+    }
+
+    return routeParams;
+  }
+
+  /**
+   * Get the regex pattern to be used for matching/extracting route param values.
+   * @param path - The path to create a regex for.
+   * @return A RegExp object with a matching group for each param.
+   */
+  protected getRouteRegex(path: string): RegExp {
+    // split the string on { } path param indicators
+    const parts = path.split(/\{|\}/g);
+    let pattern = "";
+    for (let i = 0; i < parts.length; i++) {
+      const isPathParam = i % 2 === 1;
+      if (!isPathParam) {
+        pattern += parts[i].replace(/\//g, "\\/");
+      } else {
+        pattern += "(.*?)";
+      }
+    }
+    return new RegExp(`^${pattern}$`);
+  }
+}

--- a/packages/api/src/controllers/IndexController.ts
+++ b/packages/api/src/controllers/IndexController.ts
@@ -9,10 +9,10 @@ export class IndexController {
   constructor() {
     this.name = "namely";
   }
-  @Route("/")
-  index(ctx: any): string {
-    console.log(ctx);
-    return "LOL!" + this.name;
+  @Route("/{username}/{action}")
+  index(username: string, action: string) {
+    console.log("index");
+    return { username, action };
   }
 
   @Route("/foo")

--- a/packages/api/src/controllers/IndexController.ts
+++ b/packages/api/src/controllers/IndexController.ts
@@ -9,7 +9,6 @@ export class IndexController {
   }
   @Route("/{username}/{action}")
   index(username: string, action: string) {
-    console.log("index");
     return { username, action };
   }
 

--- a/packages/api/src/controllers/IndexController.ts
+++ b/packages/api/src/controllers/IndexController.ts
@@ -1,5 +1,3 @@
-import { AwilixContainer } from "awilix";
-import { Context } from "koa";
 import { Component } from "../reflection/Component";
 import { Route } from "../reflection/Route";
 

--- a/packages/api/src/controllers/RestRepository.ts
+++ b/packages/api/src/controllers/RestRepository.ts
@@ -22,7 +22,7 @@ export abstract class RestRepository<T> {
   }
   registerRoutes(handlers: IRouteMap): IRouteMap {
     const fallbackHandlers = {
-      [this.listRoute]: this.getAll.bind(this)
+      [this.listRoute]: this.getAll
     };
     for (const route in fallbackHandlers) {
       if (!handlers[route]) {

--- a/packages/api/src/middlewares/RouterMiddlewareFactory.ts
+++ b/packages/api/src/middlewares/RouterMiddlewareFactory.ts
@@ -1,12 +1,7 @@
-import {
-  asFunction,
-  asValue,
-  AwilixContainer,
-  AwilixResolutionError,
-  InjectionMode
-} from "awilix";
+import { asValue, AwilixContainer } from "awilix";
 import { Context, Middleware } from "koa";
 import { asClassMethod } from "../AwilixHelpers";
+import { RouteTransformationService } from "../config/RouteTransformationService";
 import { IRouter } from "../reflection/IRouterClass";
 import { IMiddlewareFactory } from "./IMiddlewareFactory";
 import { INextCallback } from "./INextCallback";
@@ -30,109 +25,85 @@ export function classMethodHandler(
   };
 }
 
-function getRouteRegex(path: string): RegExp {
-  const parts = path.split(/\{|\}/g);
-  let pattern = "";
-  const pathVariables: Array<{ name: string; value: any }> = [];
-  for (let i = 0; i < parts.length; i++) {
-    const isPathParam = i % 2 === 1;
-    if (!isPathParam) {
-      pattern += parts[i].replace(/\//g, "\\/");
-    } else {
-      pattern += "(.*?)";
-    }
-  }
-  return new RegExp(`^${pattern}$`);
-}
-
-function getPathVariables(
-  path: string
-): Array<{ name: string; value: string }> {
-  const parts = path.split(/\{|\}/g);
-  const pathVariables: Array<{ name: string; value: string }> = [];
-
-  for (let i = 0; i < parts.length; i++) {
-    if (i % 2 === 0) {
-      continue;
-    }
-    pathVariables.push({
-      name: parts[i],
-      value: undefined
-    });
-  }
-
-  return pathVariables;
-}
-
-const getHandler = (
-  handlers: IRouteMap,
-  requestPath: string
-): {
-  handler: IRouteHandler;
-  pathVariables?: Array<{ name: string; value: string }>;
-} => {
-  // 1. Exact matches first
-  if (handlers[requestPath]) {
-    return {
-      handler: handlers[requestPath]
-    };
-  }
-
-  // 2. Regex matches otherwise
-  for (const path in handlers) {
-    if (path.includes("{")) {
-      console.log(path);
-      const regex = getRouteRegex(path);
-      console.log(regex);
-      const result = regex.exec(requestPath);
-      console.log(result);
-      if (!result) {
-        continue;
-      }
-
-      const pathVariables = getPathVariables(path);
-      let j = 0;
-      for (const pathVariable of pathVariables) {
-        pathVariable.value = result[j + 1];
-        j++;
-      }
-      return { handler: handlers[path], pathVariables };
-    }
-  }
-};
 export class RouterMiddlewareFactory implements IMiddlewareFactory {
+  private routeTransformationService: RouteTransformationService;
   private handlers: IRouteMap;
   private container: AwilixContainer;
-  constructor(handlers: IRouteMap, container: AwilixContainer) {
+  constructor(
+    handlers: IRouteMap,
+    container: AwilixContainer,
+    routeTransformationService: RouteTransformationService
+  ) {
     this.handlers = handlers;
     this.container = container;
+    this.routeTransformationService = routeTransformationService;
   }
   create(): Middleware {
     return async (ctx: Context, next: INextCallback) => {
       const path: string = ctx.path;
-      // Create a request-scoped DI container
-      // this is a good start, but we should elevate this
-      // that way we can have other middlewares interact with the container
-      // for example, we'll probably want a security middleware that can
-      // provide user information to the container.
+
+      /**
+       * Lookup the appropriate handler for this request, and parse
+       * any path variables.
+       */
+      const getHandler = () => {
+        // Exact match (but don't get weird if people literally enter {id})
+        if (!path.includes("{")) {
+          if (this.handlers[path]) {
+            return {
+              handler: this.handlers[path]
+            };
+          }
+        }
+
+        for (const route in this.handlers) {
+          // Find all potential wildcard routes
+          if (route.includes("{")) {
+            const parsedRoute = this.routeTransformationService.parseRoute(
+              route
+            );
+            const pathVariables = this.routeTransformationService.getPathVariables(
+              parsedRoute,
+              path
+            );
+            if (pathVariables) {
+              // variables successfully extracted, we have a match.
+              return {
+                handler: this.handlers[route],
+                pathVariables
+              };
+            }
+          }
+        }
+      };
+
+      // Create the request-scoped DI container
       const requestContainer: AwilixContainer = this.container.createScope();
 
       // Register the koa context to the request-scoped DI container
       requestContainer.register("ctx", asValue(ctx));
-      const handler = getHandler(this.handlers, path);
+
+      const handler = getHandler();
+
       if (handler) {
         const { invokeOn: instance, fn: method } = handler.handler;
         if (handler.pathVariables) {
-          handler.pathVariables.forEach(pathVariable => {
+          // register path variables for DI
+          Object.keys(handler.pathVariables).forEach(variable => {
             requestContainer.register(
-              pathVariable.name,
-              asValue(pathVariable.value)
+              variable,
+              asValue(handler.pathVariables[variable])
             );
           });
         }
+
         ctx.state.result = await requestContainer.build(
           asClassMethod(instance, method)
         );
+      }
+      // Catchall for now
+      if (ctx.state.result === undefined) {
+        ctx.state.result = "Not Found.";
       }
       await next();
     };

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -21,7 +21,6 @@
   ],
   "exclude": [
     "./node_modules/**/*",
-    "./*.js",
-    "src/**/*.spec.ts"
+    "./*.js"
   ]
 }

--- a/packages/api/yarn.lock
+++ b/packages/api/yarn.lock
@@ -123,7 +123,7 @@
   resolved "https://registry.yarnpkg.com/@types/http-assert/-/http-assert-1.3.0.tgz#5e932606153da28e1d04f9043f4912cf61fd55dd"
   integrity sha512-RObYTpPMo0IY+ZksPtKHsXlYFRxsYIvUqd68e89Y7otDrXsjBy1VgMd53kxVV0JMsNlkCASjllFOlLlhxEv0iw==
 
-"@types/jest@^23.3.2":
+"@types/jest@^23.3.3":
   version "23.3.3"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-23.3.3.tgz#246ebcc52771d2327bb8e37aa971b412d9dc4237"
   integrity sha512-G6EBrbjWDfmIpYu8UcRBOhwtDiYaLj5N5jUR5rx0YvbKxRBhXPZVLUmtfShewSUNKiQwpHavpML69a2WMbIlEQ==


### PR DESCRIPTION
support for `@Route` paths like /foo/{id}, the annotated method will be injected with the parts as
strings using the names specified.

fix #41