### PR TITLE
[53] feat(api): add http verb selection support to @Route decorator

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -32,7 +32,7 @@
     "tslint": "^5.11.0",
     "tslint-config-prettier": "^1.15.0",
     "tslint-plugin-prettier": "^1.3.0",
-    "typescript": "^3.0.3"
+    "typescript": "^3.1.2"
   },
   "config": {
     "commitizen": {

--- a/packages/api/src/HttpMethod.spec.ts
+++ b/packages/api/src/HttpMethod.spec.ts
@@ -1,0 +1,15 @@
+import { getMethod, HttpMethod } from "./HttpMethod";
+
+describe("util:HttpMethod", () => {
+  describe("function:getMethod", () => {
+    [
+      ["GET", HttpMethod.GET],
+      ["PATCH", HttpMethod.PATCH],
+      ["FOOBAR", undefined]
+    ].forEach(([str, httpMethod]) => {
+      it("maps", () => {
+        expect(getMethod(str)).toBe(httpMethod);
+      });
+    });
+  });
+});

--- a/packages/api/src/HttpMethod.ts
+++ b/packages/api/src/HttpMethod.ts
@@ -1,0 +1,19 @@
+export enum HttpMethod {
+  GET = "GET",
+  POST = "POST",
+  PATCH = "PATCH",
+  PUT = "PUT",
+  DELETE = "DELETE",
+  OPTIONS = "DELETE"
+}
+
+/**
+ * Convert a string http method to an HttpMethod enum member.
+ * @param method - One of "GET", "POST", etc.
+ * @return The matching HttpMethod, or undefined if it is unknown.
+ */
+export function getMethod(method: string): HttpMethod {
+  if (HttpMethod.hasOwnProperty(method)) {
+    return (HttpMethod as any)[method];
+  }
+}

--- a/packages/api/src/config/RouteComponentProcessor.ts
+++ b/packages/api/src/config/RouteComponentProcessor.ts
@@ -1,5 +1,7 @@
 import { AwilixContainer } from "awilix";
+import { HttpMethod } from "../HttpMethod";
 import {
+  IRequestHandler,
   IRouteHandler,
   IRouteMap
 } from "../middlewares/RouterMiddlewareFactory";
@@ -10,7 +12,11 @@ import {
   isRouterClass
 } from "../reflection/IRouterClass";
 import { IScannableClass } from "../reflection/ScannableClass";
-import { routableMethods, targetRoute } from "../reflection/Symbols";
+import {
+  httpMethods,
+  routableMethods,
+  targetRoute
+} from "../reflection/Symbols";
 import { ComponentRegistrar } from "./context/ComponentRegistrar";
 
 /**
@@ -62,15 +68,22 @@ export class RouteComponentProcessor {
       if (router[routableMethods]) {
         router[routableMethods].forEach(routableMethod => {
           const route: string = routableMethod[targetRoute];
+          // the HTTP verbs we are registering for
+          const methods = routableMethod[httpMethods];
           // Register the method as a route handler, provide context so that
           // `this` can be set intuitively for class members.
-          const handler: IRouteHandler = {
+          const handler: IRequestHandler = {
             methodName: routableMethod.name,
             invokeOn: router,
             fn: routableMethod
           };
           // Commit the registration to the result map
-          handlers[route] = handler;
+          methods.forEach(httpMethod => {
+            if (!handlers[route]) {
+              handlers[route] = {};
+            }
+            handlers[route][httpMethod] = handler;
+          });
         });
       }
       return router;

--- a/packages/api/src/controllers/IndexController.ts
+++ b/packages/api/src/controllers/IndexController.ts
@@ -1,3 +1,4 @@
+import { HttpMethod } from "../HttpMethod";
 import { Component } from "../reflection/Component";
 import { Route } from "../reflection/Route";
 
@@ -11,8 +12,10 @@ export class IndexController {
   index(username: string, action: string) {
     return { username, action, name: this.name };
   }
-
-  @Route("/foo")
+  @Route({
+    route: "/foo",
+    method: HttpMethod.POST
+  })
   foo(): string {
     return "goodbye";
   }

--- a/packages/api/src/controllers/RestRepository.ts
+++ b/packages/api/src/controllers/RestRepository.ts
@@ -1,4 +1,5 @@
 import { Connection, Repository } from "typeorm";
+import { HttpMethod } from "../HttpMethod";
 import {
   classMethodHandler,
   IRouteMap
@@ -22,11 +23,23 @@ export abstract class RestRepository<T> {
   }
   registerRoutes(handlers: IRouteMap): IRouteMap {
     const fallbackHandlers = {
-      [this.listRoute]: this.getAll
+      [this.listRoute]: {
+        fn: this.getAll,
+        method: HttpMethod.GET
+      }
     };
     for (const route in fallbackHandlers) {
       if (!handlers[route]) {
-        handlers[route] = classMethodHandler(this, fallbackHandlers[route]);
+        const method = fallbackHandlers[route].method;
+        // TODO: This isn't super pleasant. There should be a real API for this.
+        // one with docs, and less bullshit.
+        if (!handlers[route]) {
+          handlers[route] = {};
+        }
+        handlers[route][method] = classMethodHandler(
+          this,
+          fallbackHandlers[route].fn
+        );
       }
     }
     return handlers;

--- a/packages/api/src/middlewares/RouterMiddlewareFactory.ts
+++ b/packages/api/src/middlewares/RouterMiddlewareFactory.ts
@@ -2,22 +2,35 @@ import { asValue, AwilixContainer } from "awilix";
 import { Context, Middleware } from "koa";
 import { asClassMethod } from "../AwilixHelpers";
 import { RouteTransformationService } from "../config/RouteTransformationService";
+import { getMethod, HttpMethod } from "../HttpMethod";
 import { IRouter } from "../reflection/IRouterClass";
 import { IMiddlewareFactory } from "./IMiddlewareFactory";
 import { INextCallback } from "./INextCallback";
-export interface IRouteHandler {
+/**
+ * Object mapping http methods to request handlers for a given route.
+ */
+export type IRouteHandler = { [method in HttpMethod]?: IRequestHandler };
+
+/**
+ * Object containing all necessary information to invoke a routable method as
+ * a request handler.
+ */
+export interface IRequestHandler {
   methodName?: string;
   invokeOn?: IRouter;
   fn?: (...args: any[]) => any;
 }
+/**
+ * Object mapping http methods and routes to an appropriate handler.
+ */
 export interface IRouteMap {
-  [route: string]: IRouteHandler;
+  [route: string]: IRouteHandler | undefined;
 }
 
 export function classMethodHandler(
   instance: any,
   method: (...args: any[]) => any
-): IRouteHandler {
+): IRequestHandler {
   return {
     methodName: method.name,
     invokeOn: instance,
@@ -41,12 +54,29 @@ export class RouterMiddlewareFactory implements IMiddlewareFactory {
   create(): Middleware {
     return async (ctx: Context, next: INextCallback) => {
       const path: string = ctx.path;
+      const method: HttpMethod = getMethod(ctx.method);
+      if (!method) {
+        // https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html
+        // 10.5.2 501 Not Implemented
+        // "The server does not support the functionality required to fulfill
+        // the request. This is the appropriate response when the server does
+        // not recognize the request method and is not capable of supporting it
+        // for any resource."
+        ctx.state.result = `${ctx.method}`;
+        ctx.status = 501;
+      }
 
       /**
        * Lookup the appropriate handler for this request, and parse
        * any path variables.
+       * @return undefined if the route is not registered, otherwise an object
+       *    with a route handler (map of methods to request handlers), and
+       *    a (optionally) a map of the path variables.
        */
-      const getHandler = () => {
+      const getHandler: () => {
+        handler: IRouteHandler;
+        pathVariables?: { [key: string]: any };
+      } = () => {
         // Exact match (but don't get weird if people literally enter {id})
         if (!path.includes("{")) {
           if (this.handlers[path]) {
@@ -59,6 +89,8 @@ export class RouterMiddlewareFactory implements IMiddlewareFactory {
         for (const route in this.handlers) {
           // Find all potential wildcard routes
           if (route.includes("{")) {
+            // TODO: This could be cached. Calculating on every request seems
+            // wasteful.
             const parsedRoute = this.routeTransformationService.parseRoute(
               route
             );
@@ -68,6 +100,7 @@ export class RouterMiddlewareFactory implements IMiddlewareFactory {
             );
             if (pathVariables) {
               // variables successfully extracted, we have a match.
+              // check if we can support this verb
               return {
                 handler: this.handlers[route],
                 pathVariables
@@ -83,27 +116,35 @@ export class RouterMiddlewareFactory implements IMiddlewareFactory {
       // Register the koa context to the request-scoped DI container
       requestContainer.register("ctx", asValue(ctx));
 
-      const handler = getHandler();
-
-      if (handler) {
-        const { invokeOn: instance, fn: method } = handler.handler;
-        if (handler.pathVariables) {
-          // register path variables for DI
-          Object.keys(handler.pathVariables).forEach(variable => {
-            requestContainer.register(
-              variable,
-              asValue(handler.pathVariables[variable])
-            );
-          });
+      const result = getHandler();
+      if (result) {
+        const { handler, pathVariables } = result;
+        if (handler[method]) {
+          const { invokeOn: instance, fn } = handler[method];
+          if (pathVariables) {
+            // register path variables for DI
+            Object.keys(pathVariables).forEach(variable => {
+              requestContainer.register(
+                variable,
+                asValue(pathVariables[variable])
+              );
+            });
+          }
+          // invoke the routable method
+          ctx.state.result = await requestContainer.build(
+            asClassMethod(instance, fn)
+          );
+        } else {
+          // method not supported
+          ctx.status = 405;
+          ctx.set("Allow", Object.keys(handler).join(", "));
+          ctx.state.result = `${method} not allowed.`;
         }
-
-        ctx.state.result = await requestContainer.build(
-          asClassMethod(instance, method)
-        );
       }
       // Catchall for now
       if (ctx.state.result === undefined) {
         ctx.state.result = "Not Found.";
+        ctx.status = 404;
       }
       await next();
     };

--- a/packages/api/src/reflection/IRoutableMethod.ts
+++ b/packages/api/src/reflection/IRoutableMethod.ts
@@ -1,8 +1,10 @@
+import { HttpMethod } from "../HttpMethod";
 import { IDecoratedMethod } from "./ScannableClass";
-import { isRoutable, targetRoute } from "./Symbols";
+import { httpMethods, isRoutable, targetRoute } from "./Symbols";
 
 export interface IRoutableMethod extends IDecoratedMethod {
   (..._: any[]): any;
   [isRoutable]: true;
   [targetRoute]: string;
+  [httpMethods]: HttpMethod[];
 }

--- a/packages/api/src/reflection/Route.ts
+++ b/packages/api/src/reflection/Route.ts
@@ -1,26 +1,63 @@
+import { request } from "https";
+import { HttpMethod } from "../HttpMethod";
 import { IRoutableMethod } from "./IRoutableMethod";
 import { IRouterClass } from "./IRouterClass";
 import {
   decoratedType,
   DecoratedTypes,
+  httpMethods,
   isRoutable,
   isRouter,
   routableMethods,
   targetRoute
 } from "./Symbols";
 
-export function Route(route: string) {
+export function Route(
+  route: string | { route: string; method?: HttpMethod | HttpMethod[] }
+) {
   return function(
     target: any,
     propertyKey: string,
     descriptor: PropertyDescriptor
   ) {
     const value = descriptor.value as IRoutableMethod;
+    let requestedRoute: string;
+    let requestedMethods: HttpMethod[];
+    if (typeof route === "string") {
+      // simple version, use the provided route and default methods
+      requestedRoute = route;
+      requestedMethods = [
+        HttpMethod.GET,
+        HttpMethod.POST,
+        HttpMethod.PATCH,
+        HttpMethod.PUT,
+        HttpMethod.DELETE
+      ];
+    } else {
+      // configuration object provided
+      requestedRoute = route.route;
+      if (route.method) {
+        // support non-array for single methods since this is the most common
+        // anticipated usage.
+        // eg: @Route({method: "POST", route: "/foo"})
+        // vs: @Route({method: ["POST"], route: "/foo"})
+        if (!Array.isArray(route.method)) {
+          route.method = [route.method];
+        }
+        requestedMethods = [...route.method];
+      } else {
+        throw new Error(
+          `Decorator:@Route: No methods defined for ${requestedRoute} (${
+            target.constructor ? target.constructor.name : "{unknown}"
+          }.${value.name})`
+        );
+      }
+    }
     value[isRoutable] = true;
-    value[targetRoute] = route;
+    value[targetRoute] = requestedRoute;
+    value[httpMethods] = requestedMethods;
     value[decoratedType] = DecoratedTypes.METHOD;
     (target.constructor as IRouterClass)[isRouter] = true;
-
     if (!target[routableMethods]) {
       target[routableMethods] = [];
     }

--- a/packages/api/src/reflection/Symbols.ts
+++ b/packages/api/src/reflection/Symbols.ts
@@ -4,6 +4,7 @@ export const isRouter: unique symbol = Symbol("isRouter");
 export const targetRoute: unique symbol = Symbol("targetRoute");
 export const decoratedType: unique symbol = Symbol("decoratedType");
 export const routableMethods: unique symbol = Symbol("routableMethods");
+export const httpMethods: unique symbol = Symbol("httpMethods");
 export enum DecoratedTypes {
   CLASS,
   METHOD

--- a/packages/api/yarn.lock
+++ b/packages/api/yarn.lock
@@ -5548,10 +5548,10 @@ typeorm@^0.2.7:
     yargonaut "^1.1.2"
     yargs "^11.1.0"
 
-typescript@^3.0.3:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.1.tgz#3362ba9dd1e482ebb2355b02dfe8bcd19a2c7c96"
-  integrity sha512-Veu0w4dTc/9wlWNf2jeRInNodKlcdLgemvPsrNpfu5Pq39sgfFjvIIgTsvUHCoLBnMhPoUA+tFxsXjU6VexVRQ==
+typescript@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.2.tgz#c03a5d16f30bb60ad8bb6fe8e7cb212eedeec950"
+  integrity sha512-gOoGJWbNnFAfP9FlrSV63LYD5DJqYJHG5ky1kOXSl3pCImn4rqWy/flyq1BRd4iChQsoCqjbQaqtmXO4yCVPCA==
 
 uglify-js@^3.1.4:
   version "3.4.9"


### PR DESCRIPTION
fix #53 

- Accomplished via a config object passed into `@Route` instead of a string.
- Adds an application-level automatic valid HTTP 405 response for routes with some (but not all) http methods configured
- Adds an HttpMethod enum
- Adds more confusion about a class method vs an http method. Maybe it would have been best to, refer to it as "verb" more consistently.
