### PR TITLE
[91] Proxy-based injection

### DIFF
--- a/packages/api/src/AwilixHelpers.ts
+++ b/packages/api/src/AwilixHelpers.ts
@@ -2,70 +2,6 @@ import { ContextContainer } from "./config/context/ApplicationContext";
 import { RequestContext } from "./config/context/RequestContext";
 
 /**
- * An unpleasant bit of hackery to make Awilix play nice with bound functions.
- * Relies on some pretty specific implementation details in Awilix, so probably
- * pretty brittle. This is necessary to facilitate CLASSIC mode injection, as it
- * does some parsing of the function's toString() result.
- * @param instance - The class instance to bind the function to (to preserve
- *    `this` semantics)
- * @param method - The method to wrap.
- * @return A modified version of method.bind(instance) that is friendly towards
- *    Awilix's notion of a "function".
- * @example container.build(asClassMethod(someService, someService.someMethod))
- */
-export function asClassMethod<T>(
-  instance: any,
-  method: (...args: any[]) => T
-): (...args: any[]) => T {
-  // Bind the function to the instance, so that `this` is correctly set.
-  const injectable = method.bind(instance);
-  // Function.name is read-only, so modify its property descriptor directly.
-  // otherwise it gets left with something like "bound ${name}"
-  Object.getOwnPropertyDescriptor(injectable, "name").value = method.name;
-  makeProxyAwilixFriendly(injectable, method);
-  return injectable;
-}
-
-/**
- * Create a resolver for a static class method.
- * @param method The static method to register
- * @example container.build(asStaticMethod(SomeClass.someStaticMethod))
- */
-export function asStaticMethod(method: (...args: any[]) => any) {
-  // Create a proxy function so we don't pollute the real function's
-  // toString() method.
-  const injectable = (...args: any[]) => method(...args);
-  makeProxyAwilixFriendly(injectable, method);
-  return injectable;
-}
-
-/* Private Functions */
-/**
- * When Awilix is parsing functions for classic mode DI injection, it analyzes
- * the result of `fn.toString()`. This does not play well with typescript class
- * methods since their toString method looks like `functionName(args)` instead of
- * `function functionName(args)` or `(args) =>`. This function attaches a
- * toString() method to the given injectable proxy, which provides a result
- * that can be properly parsed for classic DI injection.
- * @param injectable - The proxy to modify.
- * @param realFunction - The underlying function to proxy for injection.
- */
-function makeProxyAwilixFriendly(
-  injectable: (...args: any[]) => any,
-  realFunction: (...args: any[]) => any
-) {
-  injectable.toString = () => {
-    let result = realFunction.toString();
-    let prefix = "function";
-    if (result.startsWith("async")) {
-      result = result.replace(/async/, "");
-      prefix = "async " + prefix;
-    }
-    return prefix + " " + result;
-  };
-}
-
-/**
  * Apply the ContainerAware mixin to this class. You must provide this.container
  * @provides buildMethod
  * @example
@@ -99,6 +35,7 @@ export abstract class ContainerAware {
   buildMethod<T extends (context: RequestContext) => any>(
     fn: T
   ): ReturnType<T> {
-    return this.container.build(asClassMethod(this, fn));
+    const func = fn.bind(this) as T;
+    return this.container.build(func);
   }
 }

--- a/packages/api/src/AwilixHelpers.ts
+++ b/packages/api/src/AwilixHelpers.ts
@@ -35,7 +35,18 @@ export abstract class ContainerAware {
   buildMethod<T extends (context: RequestContext) => any>(
     fn: T
   ): ReturnType<T> {
-    const func = fn.bind(this) as T;
-    return this.container.build(func);
+    return this.container.build(bind(fn, this));
   }
+}
+
+/**
+ * Type-safe `function#bind`
+ * @param fn - The function to bind
+ * @param thisArg - The `this` value for the bound function
+ */
+export function bind<T extends (this: U, ...args: any) => any, U>(
+  fn: T,
+  thisArg: any
+) {
+  return fn.bind(thisArg) as T;
 }

--- a/packages/api/src/AwilixHelpers.ts
+++ b/packages/api/src/AwilixHelpers.ts
@@ -1,5 +1,5 @@
-import { AwilixContainer } from "awilix";
-import { AnyFunction } from "./reflection/AnyFunction";
+import { ContextContainer } from "./config/context/ApplicationContext";
+import { RequestContext } from "./config/context/RequestContext";
 
 /**
  * An unpleasant bit of hackery to make Awilix play nice with bound functions.
@@ -88,15 +88,17 @@ export const MakeContainerAware: () => ClassDecorator = () => (
  * @MakeContainerAware()
  */
 export abstract class ContainerAware {
-  protected container: AwilixContainer;
-  constructor(container: AwilixContainer) {
+  protected container: ContextContainer<any>;
+  constructor(container: ContextContainer<any>) {
     this.container = container;
   }
   /**
    * Construct the provided method using this instance's container.
    * @param fn - A method on this object to build.
    */
-  buildMethod<T extends AnyFunction>(fn: T): ReturnType<T> {
+  buildMethod<T extends (context: RequestContext) => any>(
+    fn: T
+  ): ReturnType<T> {
     return this.container.build(asClassMethod(this, fn));
   }
 }

--- a/packages/api/src/HalloweenAppDevRunner.ts
+++ b/packages/api/src/HalloweenAppDevRunner.ts
@@ -53,11 +53,11 @@ export class HalloweenAppDevRunner implements IHalloweenAppRunner {
 }
 
 declare global {
-  interface ApplicationContext {
+  interface ApplicationContextMembers {
     /** The environment hash for this process */
-    NODE_ENV: typeof process.env;
+    NODE_ENV: Partial<ENV_VARS>;
     /** The awilix container that holds this context */
-    container: AwilixContainer;
+    container: ContextContainer<ApplicationContext>;
     /** Service for interacting with the process env */
     envService: EnvService;
   }

--- a/packages/api/src/HalloweenAppDevRunner.ts
+++ b/packages/api/src/HalloweenAppDevRunner.ts
@@ -1,16 +1,15 @@
-import {
-  asClass,
-  asValue,
-  AwilixContainer,
-  createContainer,
-  InjectionMode
-} from "awilix";
+import { asClass, asValue, createContainer } from "awilix";
 import { asStaticMethod } from "./AwilixHelpers";
+import {
+  ApplicationContainer,
+  ApplicationContext,
+  ContextContainer
+} from "./config/context/ApplicationContext";
 import { ComponentRegistrar } from "./config/context/ComponentRegistrar";
 import { OrmContext } from "./config/context/OrmContext";
 import { WebserverContext } from "./config/context/WebserverContext";
+import { ENV_VARS } from "./config/env/ENV_VARS";
 import { EnvService } from "./config/env/EnvService";
-import { KoaConfiguration } from "./config/KoaConfiguration";
 import { IHalloweenAppRunner } from "./IHalloweenAppRunner";
 import { ExportPathScanner } from "./reflection/ExportPathScanner";
 
@@ -19,9 +18,7 @@ export class HalloweenAppDevRunner implements IHalloweenAppRunner {
     // Proof of concept: classpath scanning
     const components = await ExportPathScanner.scan("./dist/**/*.js");
     // Container configuration step
-    const container = createContainer({
-      injectionMode: InjectionMode.CLASSIC
-    });
+    const container = createContainer() as ApplicationContainer;
 
     // Register the node environment for injection
     container.register("NODE_ENV", asValue(process.env));
@@ -46,9 +43,8 @@ export class HalloweenAppDevRunner implements IHalloweenAppRunner {
     await ComponentRegistrar.configureContainer(container, components);
 
     // Hook up middlewares and start the webserver listening
-    const koaConfiguration: KoaConfiguration =
-      container.cradle.koaConfiguration;
-    koaConfiguration.configure();
+    const koaConfiguration = container.resolve("koaConfiguration");
+    container.build(koaConfiguration.configure);
   }
 }
 

--- a/packages/api/src/HalloweenAppDevRunner.ts
+++ b/packages/api/src/HalloweenAppDevRunner.ts
@@ -1,5 +1,4 @@
 import { asClass, asValue, createContainer } from "awilix";
-import { asStaticMethod } from "./AwilixHelpers";
 import {
   ApplicationContainer,
   ApplicationContext,
@@ -34,10 +33,10 @@ export class HalloweenAppDevRunner implements IHalloweenAppRunner {
     // Wire up our persistence layer. This is asynchronous and so needs
     // to have its own flow outside of the normal awilix instantiation
     // process.
-    await container.build(asStaticMethod(OrmContext.configureContainer));
+    await container.build(OrmContext.configureContainer);
 
     // Wire up our web layer
-    await container.build(asStaticMethod(WebserverContext.configureContainer));
+    await container.build(WebserverContext.configureContainer);
 
     // Register all @components with our DI container
     await ComponentRegistrar.configureContainer(container, components);

--- a/packages/api/src/HalloweenAppDevRunner.ts
+++ b/packages/api/src/HalloweenAppDevRunner.ts
@@ -1,4 +1,10 @@
-import { asClass, asValue, createContainer, InjectionMode } from "awilix";
+import {
+  asClass,
+  asValue,
+  AwilixContainer,
+  createContainer,
+  InjectionMode
+} from "awilix";
 import { asStaticMethod } from "./AwilixHelpers";
 import { ComponentRegistrar } from "./config/context/ComponentRegistrar";
 import { OrmContext } from "./config/context/OrmContext";
@@ -43,5 +49,16 @@ export class HalloweenAppDevRunner implements IHalloweenAppRunner {
     const koaConfiguration: KoaConfiguration =
       container.cradle.koaConfiguration;
     koaConfiguration.configure();
+  }
+}
+
+declare global {
+  interface ApplicationContext {
+    /** The environment hash for this process */
+    NODE_ENV: typeof process.env;
+    /** The awilix container that holds this context */
+    container: AwilixContainer;
+    /** Service for interacting with the process env */
+    envService: EnvService;
   }
 }

--- a/packages/api/src/auth/AuthenticationService.ts
+++ b/packages/api/src/auth/AuthenticationService.ts
@@ -1,7 +1,7 @@
 import { ROLES } from "@clovercoin/constants";
 import { TokenExpiredError } from "jsonwebtoken";
 import { Repository } from "typeorm";
-import { RequestContext } from "../config/context/RequestContext";
+import { ApplicationContext } from "../config/context/ApplicationContext";
 import { Role, User } from "../models";
 import { Component } from "../reflection/Component";
 import { AuthenticationFailureException } from "./AuthenticationFailureException";
@@ -21,7 +21,7 @@ export class AuthenticationService {
     roleRepository,
     userRepository,
     tokenService
-  }: RequestContext) {
+  }: ApplicationContext) {
     this.client = deviantartApiConsumer;
     this.roleRepository = roleRepository;
     this.userRepository = userRepository;

--- a/packages/api/src/auth/AuthenticationService.ts
+++ b/packages/api/src/auth/AuthenticationService.ts
@@ -87,3 +87,9 @@ export class AuthenticationService {
     }
   }
 }
+
+declare global {
+  interface ApplicationContextMembers {
+    authenticationService: AuthenticationService;
+  }
+}

--- a/packages/api/src/auth/AuthenticationService.ts
+++ b/packages/api/src/auth/AuthenticationService.ts
@@ -1,6 +1,7 @@
 import { ROLES } from "@clovercoin/constants";
 import { TokenExpiredError } from "jsonwebtoken";
 import { Repository } from "typeorm";
+import { RequestContext } from "../config/context/RequestContext";
 import { Role, User } from "../models";
 import { Component } from "../reflection/Component";
 import { AuthenticationFailureException } from "./AuthenticationFailureException";
@@ -11,13 +12,20 @@ import { TokenService } from "./TokenService";
 @Component()
 export class AuthenticationService {
   private client: DeviantartApiConsumer;
-  constructor(
-    deviantartApiConsumer: DeviantartApiConsumer,
-    private roleRepository: Repository<Role>,
-    private userRepository: Repository<User>,
-    private tokenService: TokenService
-  ) {
+  private roleRepository: Repository<Role>;
+  private userRepository: Repository<User>;
+  private tokenService: TokenService;
+  /** @inject */
+  constructor({
+    deviantartApiConsumer,
+    roleRepository,
+    userRepository,
+    tokenService
+  }: RequestContext) {
     this.client = deviantartApiConsumer;
+    this.roleRepository = roleRepository;
+    this.userRepository = userRepository;
+    this.tokenService = tokenService;
   }
 
   /**

--- a/packages/api/src/auth/LoginController.ts
+++ b/packages/api/src/auth/LoginController.ts
@@ -1,5 +1,5 @@
-import { Context } from "koa";
 import { Repository } from "typeorm";
+import { RequestContext } from "../config/context/RequestContext";
 import { HttpMethod } from "../HttpMethod";
 import { User } from "../models";
 import { Component } from "../reflection/Component";
@@ -10,19 +10,18 @@ import { AuthenticationService } from "./AuthenticationService";
 export class LoginController {
   private authService: AuthenticationService;
   private userRepository: Repository<User>;
-  constructor(
-    authenticationService: AuthenticationService,
-    userRepository: Repository<User>
-  ) {
+  /** @inject */
+  constructor({ authenticationService, userRepository }: RequestContext) {
     this.authService = authenticationService;
     this.userRepository = userRepository;
   }
+  /** @inject */
   @Route({
     route: "/login",
     method: HttpMethod.POST,
     roles: ["public"]
   })
-  async handleLogin(requestBody: { authCode?: string }) {
+  async handleLogin({ requestBody }: RequestContext) {
     if (!requestBody.authCode) {
       // todo: return a bad request http response
       return;
@@ -31,13 +30,13 @@ export class LoginController {
       token: await this.authService.authenticate(requestBody.authCode)
     };
   }
-
+  /** @inject */
   @Route({
     route: "/whoami",
     method: HttpMethod.GET,
     roles: ["user"]
   })
-  async whoami(ctx: Context): Promise<User> {
+  async whoami({ ctx }: RequestContext): Promise<User> {
     const token = ctx.get("Authorization").replace("Bearer ", "");
     const payload = await this.authService.authenticateToken(token);
     return this.userRepository.findOne(payload.sub);

--- a/packages/api/src/auth/TokenService.ts
+++ b/packages/api/src/auth/TokenService.ts
@@ -15,6 +15,7 @@ export class TokenService {
    * EnvService.
    * @param envService - The environment service from which to fetch token
    * configuration info
+   * @inject
    */
   constructor({ envService }: ApplicationContext) {
     this.config = envService.getTokenConfiguration();

--- a/packages/api/src/auth/TokenService.ts
+++ b/packages/api/src/auth/TokenService.ts
@@ -1,5 +1,5 @@
 import * as JWT from "jsonwebtoken";
-import { EnvService } from "../config/env/EnvService";
+import { ApplicationContext } from "../config/context/ApplicationContext";
 import { ITokenConfiguration } from "../config/env/ITokenConfiguration";
 import { Component } from "../reflection/Component";
 import { ITokenPayload } from "./ITokenPayload";
@@ -16,7 +16,7 @@ export class TokenService {
    * @param envService - The environment service from which to fetch token
    * configuration info
    */
-  constructor(envService: EnvService) {
+  constructor({ envService }: ApplicationContext) {
     this.config = envService.getTokenConfiguration();
   }
   /**

--- a/packages/api/src/auth/TokenService.ts
+++ b/packages/api/src/auth/TokenService.ts
@@ -67,3 +67,10 @@ interface ITokenData {
   /** Deviantart api access token. */
   accessToken: string;
 }
+
+declare global {
+  interface ApplicationContext {
+    /** Service for managing JWTs */
+    tokenService: TokenService;
+  }
+}

--- a/packages/api/src/auth/TokenService.ts
+++ b/packages/api/src/auth/TokenService.ts
@@ -69,7 +69,7 @@ interface ITokenData {
 }
 
 declare global {
-  interface ApplicationContext {
+  interface ApplicationContextMembers {
     /** Service for managing JWTs */
     tokenService: TokenService;
   }

--- a/packages/api/src/auth/deviantart/DeviantartApiConsumer.ts
+++ b/packages/api/src/auth/deviantart/DeviantartApiConsumer.ts
@@ -80,8 +80,8 @@ export class DeviantartApiConsumer {
 }
 
 declare global {
-  interface ApplicationContext {
+  interface ApplicationContextMembers {
     /** API client for interacting with the DeviantArt REST API */
-    deviantArtApiConsumer: DeviantartApiConsumer;
+    deviantartApiConsumer: DeviantartApiConsumer;
   }
 }

--- a/packages/api/src/auth/deviantart/DeviantartApiConsumer.ts
+++ b/packages/api/src/auth/deviantart/DeviantartApiConsumer.ts
@@ -8,6 +8,7 @@ import { IDeviantartUser } from "./IDeviantartUser";
 @Component()
 export class DeviantartApiConsumer {
   private config: IDeviantartApiConsumerConfiguration;
+  /** @inject */
   constructor({ envService }: ApplicationContext) {
     this.config = envService.getDeviantartApiConsumerConfig();
   }

--- a/packages/api/src/auth/deviantart/DeviantartApiConsumer.ts
+++ b/packages/api/src/auth/deviantart/DeviantartApiConsumer.ts
@@ -1,6 +1,6 @@
 import Axios from "axios";
 import * as QueryString from "querystring";
-import { EnvService } from "../../config/env/EnvService";
+import { ApplicationContext } from "../../config/context/ApplicationContext";
 import { IDeviantartApiConsumerConfiguration } from "../../config/env/IDeviantartApiConsumerConfig";
 import { Component } from "../../reflection/Component";
 import { IDeviantartAuthResult } from "./IDeviantartAuthResult";
@@ -8,7 +8,7 @@ import { IDeviantartUser } from "./IDeviantartUser";
 @Component()
 export class DeviantartApiConsumer {
   private config: IDeviantartApiConsumerConfiguration;
-  constructor(envService: EnvService) {
+  constructor({ envService }: ApplicationContext) {
     this.config = envService.getDeviantartApiConsumerConfig();
   }
   /**

--- a/packages/api/src/auth/deviantart/DeviantartApiConsumer.ts
+++ b/packages/api/src/auth/deviantart/DeviantartApiConsumer.ts
@@ -78,3 +78,10 @@ export class DeviantartApiConsumer {
     };
   }
 }
+
+declare global {
+  interface ApplicationContext {
+    /** API client for interacting with the DeviantArt REST API */
+    deviantArtApiConsumer: DeviantartApiConsumer;
+  }
+}

--- a/packages/api/src/config/KoaConfiguration.ts
+++ b/packages/api/src/config/KoaConfiguration.ts
@@ -17,13 +17,14 @@ import {
 export class KoaConfiguration {
   /**
    * Configure the webserver with necessary middlewares and start it listening.
+   * @inject
    */
   configure({
     routeComponentProcessor,
     container,
     webserver,
     envService
-  }: ApplicationContextMembers) {
+  }: ApplicationContext) {
     const webserverConfig = envService.getWebserverConfig();
     routeComponentProcessor.populateRouteRegistry();
     const configContainer = container.createScope();

--- a/packages/api/src/config/KoaConfiguration.ts
+++ b/packages/api/src/config/KoaConfiguration.ts
@@ -106,7 +106,8 @@ function createMiddleware(
 }
 
 declare global {
-  interface ApplicationContext {
+  interface ApplicationContextMembers {
+    /** Configuration class that starts the webserver listening */
     koaConfiguration: KoaConfiguration;
   }
 }

--- a/packages/api/src/config/KoaConfiguration.ts
+++ b/packages/api/src/config/KoaConfiguration.ts
@@ -104,3 +104,9 @@ function createMiddleware(
 ) {
   return container.build(asClass(factoryClass)).create();
 }
+
+declare global {
+  interface ApplicationContext {
+    koaConfiguration: KoaConfiguration;
+  }
+}

--- a/packages/api/src/config/KoaConfiguration.ts
+++ b/packages/api/src/config/KoaConfiguration.ts
@@ -1,5 +1,4 @@
-import { asClass, AwilixContainer } from "awilix";
-import * as Koa from "koa";
+import { asClass } from "awilix";
 import * as BodyParser from "koa-bodyparser";
 import { AuthorizationMiddlewareFactory } from "../middlewares/AuthorizationMiddlewareFactory";
 import { CorsMiddlewareFactory } from "../middlewares/CorsMiddlewareFactory";
@@ -9,27 +8,25 @@ import { RenderMiddlewareFactory } from "../middlewares/RenderMiddlewareFactory"
 import { RequestContainerMiddlewareFactory } from "../middlewares/RequestContainerMiddlewareFactory";
 import { RouterMiddlewareFactory } from "../middlewares/RouterMiddlewareFactory";
 import { Component } from "../reflection/Component";
-import { EnvService } from "./env/EnvService";
-import { IWebserverConfiguration } from "./env/IWebserverConfiguration";
-import { RouteComponentProcessor } from "./RouteComponentProcessor";
+import {
+  ApplicationContainer,
+  ApplicationContext
+} from "./context/ApplicationContext";
 
 @Component()
 export class KoaConfiguration {
-  private webserverConfig: IWebserverConfiguration;
-  constructor(
-    private container: AwilixContainer,
-    private routeComponentProcessor: RouteComponentProcessor,
-    private webserver: Koa,
-    envService: EnvService
-  ) {
-    this.webserverConfig = envService.getWebserverConfig();
-  }
   /**
    * Configure the webserver with necessary middlewares and start it listening.
    */
-  configure() {
-    this.routeComponentProcessor.populateRouteRegistry();
-    const configContainer = this.container.createScope();
+  configure({
+    routeComponentProcessor,
+    container,
+    webserver,
+    envService
+  }: ApplicationContextMembers) {
+    const webserverConfig = envService.getWebserverConfig();
+    routeComponentProcessor.populateRouteRegistry();
+    const configContainer = container.createScope();
     // middleware for triggering controllers' @Route handlers
     const routerMiddleware = createMiddleware(
       configContainer,
@@ -62,32 +59,32 @@ export class KoaConfiguration {
     );
 
     // middleware for parsing request bodies into objects
-    this.webserver.use(BodyParser());
+    webserver.use(BodyParser());
     // the cors middleware relies on other middlewares to set the allow headers
     // so it goes first since it awaits `next()` before setting headers.
-    this.webserver.use(corsMiddleware);
+    webserver.use(corsMiddleware);
     // the request-scoped container is needed by other middleware so it is added
     // early in the chain. Some other useful request-specific stuff is configured
     // in here too.
-    this.webserver.use(requestContainerMiddleware);
+    webserver.use(requestContainerMiddleware);
     // the renderer middleware awaits `next()` before setting the response body
     // based on ctx.state.result. So any middleware that come after it in the
     // chain may control the rendered result
-    this.webserver.use(rendererMiddleware);
+    webserver.use(rendererMiddleware);
     // the error handler middleware wraps its call to `next()` in a try/catch
     // so all middlewares from here down can safely throw known error types
     // and expect them to be converted to a reasonable error responseand rendered
     // properly.
-    this.webserver.use(errorHandlerMiddleware);
+    webserver.use(errorHandlerMiddleware);
     // the authorization middleware will throw meaningful exceptions up to the
     // error handler on auth failures. Also populates the current user into
     // the request scoped DI container.
-    this.webserver.use(authorizationMiddleware);
+    webserver.use(authorizationMiddleware);
     // finally, if everything went well we actually route the request to a
     // controller.
-    this.webserver.use(routerMiddleware);
+    webserver.use(routerMiddleware);
     // start the webserver
-    this.webserver.listen(this.webserverConfig.port);
+    webserver.listen(webserverConfig.port);
   }
 }
 
@@ -99,8 +96,8 @@ export class KoaConfiguration {
  * @param factoryClass - The class to instantiate.
  */
 function createMiddleware(
-  container: AwilixContainer,
-  factoryClass: new (...args: any[]) => IMiddlewareFactory
+  container: ApplicationContainer,
+  factoryClass: new (context: ApplicationContext) => IMiddlewareFactory
 ) {
   return container.build(asClass(factoryClass)).create();
 }

--- a/packages/api/src/config/RequestParsingService.ts
+++ b/packages/api/src/config/RequestParsingService.ts
@@ -15,20 +15,23 @@ export class RequestParsingService {
    * @param ctx - The Koa context.
    * @param container - The container to register request data to.
    */
-  parse(ctx: Context, container: AwilixContainer) {
+  parse<T extends { [key: string]: any }>(
+    ctx: Context,
+    container: ContextContainer<T>
+  ) {
     container.register("requestBody", asValue(ctx.request.body));
   }
 }
 
 declare global {
-  interface ApplicationContext {
+  interface ApplicationContextMembers {
     /**
      * Service responsible for populating request data into the application
      * context.
      */
     requestParsingService: RequestParsingService;
   }
-  interface RequestContext {
+  interface RequestContextMembers {
     /** Parsed body for this request */
     requestBody: { [key: string]: any };
   }

--- a/packages/api/src/config/RequestParsingService.ts
+++ b/packages/api/src/config/RequestParsingService.ts
@@ -1,6 +1,7 @@
-import { asValue, AwilixContainer } from "awilix";
+import { asValue } from "awilix";
 import { Context } from "koa";
 import { Component } from "../reflection/Component";
+import { ContextContainer } from "./context/ApplicationContext";
 
 /**
  * Service used for parsing incoming requests into useful data.

--- a/packages/api/src/config/RequestParsingService.ts
+++ b/packages/api/src/config/RequestParsingService.ts
@@ -19,3 +19,17 @@ export class RequestParsingService {
     container.register("requestBody", asValue(ctx.request.body));
   }
 }
+
+declare global {
+  interface ApplicationContext {
+    /**
+     * Service responsible for populating request data into the application
+     * context.
+     */
+    requestParsingService: RequestParsingService;
+  }
+  interface RequestContext {
+    /** Parsed body for this request */
+    requestBody: { [key: string]: any };
+  }
+}

--- a/packages/api/src/config/RouteComponentProcessor.ts
+++ b/packages/api/src/config/RouteComponentProcessor.ts
@@ -1,4 +1,3 @@
-import { asClassMethod } from "../AwilixHelpers";
 import { Component } from "../reflection/Component";
 import {
   IRouter,
@@ -76,7 +75,7 @@ export class RouteComponentProcessor {
           this.routeRegistry.registerRoute(
             route,
             methods,
-            asClassMethod(router, routableMethod),
+            routableMethod.bind(router),
             router,
             roles
           );
@@ -92,7 +91,7 @@ export class RouteComponentProcessor {
      */
     const registerCustomRoutes = (router: IRouter) => {
       if (router.registerRoutes) {
-        this.container.build(asClassMethod(router, router.registerRoutes));
+        this.container.build(router.registerRoutes.bind(router));
       }
     };
 

--- a/packages/api/src/config/RouteComponentProcessor.ts
+++ b/packages/api/src/config/RouteComponentProcessor.ts
@@ -1,3 +1,4 @@
+import { bind } from "../AwilixHelpers";
 import { Component } from "../reflection/Component";
 import {
   IRouter,
@@ -75,7 +76,7 @@ export class RouteComponentProcessor {
           this.routeRegistry.registerRoute(
             route,
             methods,
-            routableMethod.bind(router),
+            bind(routableMethod, router),
             router,
             roles
           );
@@ -91,7 +92,7 @@ export class RouteComponentProcessor {
      */
     const registerCustomRoutes = (router: IRouter) => {
       if (router.registerRoutes) {
-        this.container.build(router.registerRoutes.bind(router));
+        this.container.build(bind(router.registerRoutes, router));
       }
     };
 

--- a/packages/api/src/config/RouteComponentProcessor.ts
+++ b/packages/api/src/config/RouteComponentProcessor.ts
@@ -107,3 +107,13 @@ export class RouteComponentProcessor {
       });
   }
 }
+
+declare global {
+  interface ApplicationContext {
+    /**
+     * Component responsible for populating the route registry with routable
+     * methods parsed from the @Component list.
+     */
+    routeComponentProcessor: RouteComponentProcessor;
+  }
+}

--- a/packages/api/src/config/RouteComponentProcessor.ts
+++ b/packages/api/src/config/RouteComponentProcessor.ts
@@ -1,4 +1,3 @@
-import { AwilixContainer } from "awilix";
 import { asClassMethod } from "../AwilixHelpers";
 import { Component } from "../reflection/Component";
 import {
@@ -14,6 +13,10 @@ import {
   targetRoute
 } from "../reflection/Symbols";
 import { RouteRegistry } from "../web/RouteRegistry";
+import {
+  ApplicationContainer,
+  ApplicationContext
+} from "./context/ApplicationContext";
 import { ComponentRegistrar } from "./context/ComponentRegistrar";
 
 /**
@@ -29,18 +32,15 @@ export class RouteComponentProcessor {
    * @member container - The application's DI container. Used to create request
    *    scoped child containers, and provide DI for route handler methods.
    */
-  private container: AwilixContainer;
+  private container: ApplicationContainer;
   /**
    * @private
    * @member componentList - The ComponentList. @see ComponentRegistrar
    */
   private componentList: IScannableClass[];
   private routeRegistry: RouteRegistry;
-  constructor(
-    container: AwilixContainer,
-    ComponentList: IScannableClass[],
-    routeRegistry: RouteRegistry
-  ) {
+  /** @inject */
+  constructor({ container, ComponentList, routeRegistry }: ApplicationContext) {
     this.container = container;
     this.componentList = ComponentList;
     this.routeRegistry = routeRegistry;
@@ -57,7 +57,9 @@ export class RouteComponentProcessor {
      */
     const getInstance = (routerClass: IRouterClass): IRouter => {
       const name = ComponentRegistrar.getRegistrationName(routerClass);
-      const registration = this.container.cradle[name];
+      const registration = this.container.cradle[
+        name as keyof ApplicationContext
+      ] as IRouter;
       return registration as IRouter;
     };
 
@@ -109,7 +111,7 @@ export class RouteComponentProcessor {
 }
 
 declare global {
-  interface ApplicationContext {
+  interface ApplicationContextMembers {
     /**
      * Component responsible for populating the route registry with routable
      * methods parsed from the @Component list.

--- a/packages/api/src/config/RouteTransformationService.ts
+++ b/packages/api/src/config/RouteTransformationService.ts
@@ -90,3 +90,9 @@ export class RouteTransformationService {
     return new RegExp(`^${pattern}$`);
   }
 }
+
+declare global {
+  interface ApplicationContextMembers {
+    routeTransformationService: RouteTransformationService;
+  }
+}

--- a/packages/api/src/config/context/ApplicationContext.ts
+++ b/packages/api/src/config/context/ApplicationContext.ts
@@ -29,6 +29,8 @@ declare global {
 }
 
 export type AnyContext = ApplicationContext | RequestContext;
+export type AnyContainer = ContextContainer<AnyContext>;
+
 export interface ContextContainer<ContextType>
   extends Assign<
     Omit<AwilixContainer, "register" | "createScope">,

--- a/packages/api/src/config/context/ApplicationContext.ts
+++ b/packages/api/src/config/context/ApplicationContext.ts
@@ -1,0 +1,2 @@
+// tslint:disable-next-line:no-empty-interface
+declare interface ApplicationContext {}

--- a/packages/api/src/config/context/ApplicationContext.ts
+++ b/packages/api/src/config/context/ApplicationContext.ts
@@ -1,2 +1,69 @@
+import { Assign, Omit } from "@clovercoin/constants";
+import {
+  AwilixContainer,
+  BuildResolverOptions,
+  ClassOrFunctionReturning,
+  ResolveOptions,
+  Resolver
+} from "awilix";
+import { RequestContext } from "./RequestContext";
+
+declare global {
+  /**
+   * Add members to this interface that should be present in the root scope DI
+   * context. Do not use this type to consume a context, instead
+   * @see ApplicationContext
+   *
+   * @example
+   * // inside of a module
+   * // @Component()
+   * export class SomeClass { . . . }
+   * declare global {
+   *   interface ApplicationContextMembers {
+   *     someClass: SomeClass;
+   *   }
+   * }
+   */
+  // tslint:disable-next-line:no-empty-interface
+  interface ApplicationContextMembers {}
+}
+
+export type AnyContext = ApplicationContext | RequestContext;
+export interface ContextContainer<ContextType>
+  extends Assign<
+    Omit<AwilixContainer, "register" | "createScope">,
+    {
+      cradle: ContextType;
+      build<U>(fn: (context: ContextType) => U): U;
+      build<T>(
+        targetOrResolver: ClassOrFunctionReturning<T> | Resolver<T>,
+        opts?: BuildResolverOptions<T>
+      ): T;
+      resolve<K extends keyof ContextType>(
+        name: K,
+        resolveOptions?: ResolveOptions
+      ): ContextType[K];
+      resolve<T>(name: string | symbol, resolveOptions?: ResolveOptions): T;
+    }
+  > {
+  // this is defined down here to allow for access to "this" type
+  register<K extends keyof ContextType, T extends ContextType[K]>(
+    name: K,
+    registration: Resolver<T>
+  ): this;
+  createScope<T extends ContextContainer<any>>(): T;
+  createScope(): this;
+}
+/**
+ * Type of the root DI container's context.
+ * @example
+ * doSomeSetup({ prizeRepository }: RequestContext) {. . .}
+ */
 // tslint:disable-next-line:no-empty-interface
-declare interface ApplicationContext {}
+export interface ApplicationContext extends ApplicationContextMembers {}
+
+/**
+ * Type of the root level application's container
+ */
+export interface ApplicationContainer
+  extends ContextContainer<ApplicationContext> {}

--- a/packages/api/src/config/context/ComponentRegistrar.ts
+++ b/packages/api/src/config/context/ComponentRegistrar.ts
@@ -37,6 +37,16 @@ export class ComponentRegistrar {
     return container;
   }
 
+  /**
+   * Get the registration name for a class in the application context. If a
+   * container is provided, this function will throw an error if it is not
+   * registered in that container.
+   * @param componentClass - The class to get a name for
+   * @param container - The container to check for
+   * @template T - The return type will be keyof T for convenience with strict
+   *  container types. Defaults to `any`, resulting in a return type of `string`
+   * @return The registration name for the class
+   */
   static getRegistrationName<T = any>(
     componentClass: IScannableClass,
     container?: ContextContainer<T>

--- a/packages/api/src/config/context/ComponentRegistrar.ts
+++ b/packages/api/src/config/context/ComponentRegistrar.ts
@@ -1,36 +1,56 @@
-import { asClass, asValue, AwilixContainer } from "awilix";
+import { asClass, asValue } from "awilix";
 import { IScannableClass } from "../../reflection/ScannableClass";
 import { lifeTime } from "../../reflection/Symbols";
+import {
+  ApplicationContainer,
+  ApplicationContext,
+  ContextContainer
+} from "./ApplicationContext";
 /**
  * @class ComponentRegistrar
  * Container configurator that registers @Component-annotated classes.
  */
 export class ComponentRegistrar {
   /**
+   * @inject
    * @static @method configureContainer - Configure the DI container with
    *    @Component's. Additionally:
    * Provides: {IScannableClass[]} container.ComponentList - A full list of all
    *    decorated component classes.
-   * @param {AwilixContainer} container - The DI container to configure.
-   * @param {IScannableClass[]} components - The components to set up.
-   * @return {AwilixContainer} The modified container.
+   * @param container - The DI container to configure.
+   * @param components - The components to set up.
+   * @return The modified container.
    */
   static configureContainer(
-    container: AwilixContainer,
+    container: ApplicationContainer,
     components: IScannableClass[]
-  ): AwilixContainer {
+  ): ApplicationContainer {
     components.forEach((componentClass: IScannableClass) => {
       container.register(
-        ComponentRegistrar.getRegistrationName(componentClass),
-        asClass(componentClass, { lifetime: componentClass[lifeTime] })
+        ComponentRegistrar.getRegistrationName<ApplicationContext>(
+          componentClass
+        ),
+        asClass(componentClass, { lifetime: componentClass[lifeTime] }) as any
       );
     });
     container.register("ComponentList", asValue(components.map(_ => _)));
     return container;
   }
 
-  static getRegistrationName(componentClass: IScannableClass): string {
-    return componentClass.name[0].toLowerCase() + componentClass.name.substr(1);
+  static getRegistrationName<T = any>(
+    componentClass: IScannableClass,
+    container?: ContextContainer<T>
+  ): keyof T {
+    const result =
+      componentClass.name[0].toLowerCase() + componentClass.name.substr(1);
+    if (!container) {
+      return result as keyof T;
+    }
+    if (container.registrations.hasOwnProperty(result)) {
+      return result as keyof T;
+    } else {
+      throw new Error("Registration not found.");
+    }
   }
 }
 

--- a/packages/api/src/config/context/ComponentRegistrar.ts
+++ b/packages/api/src/config/context/ComponentRegistrar.ts
@@ -35,7 +35,7 @@ export class ComponentRegistrar {
 }
 
 declare global {
-  interface ApplicationContext {
+  interface ApplicationContextMembers {
     ComponentList: IScannableClass[];
   }
 }

--- a/packages/api/src/config/context/ComponentRegistrar.ts
+++ b/packages/api/src/config/context/ComponentRegistrar.ts
@@ -33,3 +33,9 @@ export class ComponentRegistrar {
     return componentClass.name[0].toLowerCase() + componentClass.name.substr(1);
   }
 }
+
+declare global {
+  interface ApplicationContext {
+    ComponentList: IScannableClass[];
+  }
+}

--- a/packages/api/src/config/context/OrmContext.ts
+++ b/packages/api/src/config/context/OrmContext.ts
@@ -1,6 +1,5 @@
 import { asFunction, asValue, Lifetime } from "awilix";
 import { Connection, createConnection, EntityManager } from "typeorm";
-import { asStaticMethod } from "../../AwilixHelpers";
 import { MODELS } from "../../models";
 import { getRepositoryFor } from "../../models/modelUtils";
 import { AnyContext, ApplicationContext } from "./ApplicationContext";
@@ -63,7 +62,7 @@ export class OrmContext {
     await Promise.all(
       MODELS.map(model =>
         model.createInitialEntities
-          ? container.build(asStaticMethod(model.createInitialEntities))
+          ? container.build(model.createInitialEntities)
           : Promise.resolve()
       )
     );

--- a/packages/api/src/config/context/OrmContext.ts
+++ b/packages/api/src/config/context/OrmContext.ts
@@ -71,7 +71,7 @@ export class OrmContext {
 }
 
 declare global {
-  interface ApplicationContext {
+  interface ApplicationContextMembers {
     /** The typeorm connection for the application */
     orm: Connection;
     /** The entity manager for this container */

--- a/packages/api/src/config/context/OrmContext.ts
+++ b/packages/api/src/config/context/OrmContext.ts
@@ -1,9 +1,9 @@
-import { asFunction, asValue, AwilixContainer, Lifetime } from "awilix";
+import { asFunction, asValue, Lifetime } from "awilix";
 import { Connection, createConnection, EntityManager } from "typeorm";
 import { asStaticMethod } from "../../AwilixHelpers";
 import { MODELS } from "../../models";
 import { getRepositoryFor } from "../../models/modelUtils";
-import { EnvService } from "../env/EnvService";
+import { AnyContext, ApplicationContext } from "./ApplicationContext";
 
 /**
  * Create a repository name for the given model.
@@ -25,11 +25,12 @@ export class OrmContext {
    * Configures the DI container with ORM related registrations.
    * @configures {typeorm.Connection} orm
    * @configures {typeorm.Repository} [model]Repository for each model.
+   * @inject
    */
-  static async configureContainer(
-    container: AwilixContainer,
-    envService: EnvService
-  ) {
+  static async configureContainer({
+    container,
+    envService
+  }: ApplicationContext) {
     const config = {
       ...envService.getOrmConfiguration(),
       entities: MODELS
@@ -43,7 +44,7 @@ export class OrmContext {
     // ORM
     container.register(
       "manager",
-      asFunction((orm: Connection) => orm.manager, {
+      asFunction(({ orm }: AnyContext) => orm.manager, {
         lifetime: Lifetime.TRANSIENT
       })
     );
@@ -51,10 +52,11 @@ export class OrmContext {
     MODELS.forEach(model => {
       // Register a scoped repository for each model.
       const name = createRepositoryName(model);
-      const proxy = (manager: EntityManager) =>
+      /** @inject */
+      const proxy = ({ manager }: AnyContext) =>
         getRepositoryFor(manager, model);
       const resolver = asFunction(proxy);
-      container.register(name, resolver);
+      container.register(name as keyof ApplicationContext, resolver);
     });
 
     // Fire off createInitialEntites for each model

--- a/packages/api/src/config/context/OrmContext.ts
+++ b/packages/api/src/config/context/OrmContext.ts
@@ -69,3 +69,12 @@ export class OrmContext {
     return container;
   }
 }
+
+declare global {
+  interface ApplicationContext {
+    /** The typeorm connection for the application */
+    orm: Connection;
+    /** The entity manager for this container */
+    manager: EntityManager;
+  }
+}

--- a/packages/api/src/config/context/RequestContext.ts
+++ b/packages/api/src/config/context/RequestContext.ts
@@ -1,0 +1,2 @@
+// tslint:disable-next-line:no-empty-interface
+declare interface RequestContext extends ApplicationContext {}

--- a/packages/api/src/config/context/RequestContext.ts
+++ b/packages/api/src/config/context/RequestContext.ts
@@ -1,2 +1,44 @@
-// tslint:disable-next-line:no-empty-interface
-declare interface RequestContext extends ApplicationContext {}
+import { Assign } from "@clovercoin/constants";
+import { ApplicationContext, ContextContainer } from "./ApplicationContext";
+
+declare global {
+  /**
+   * Add members to this interface that should be present in request-scoped
+   * contexts. Do not use this type to consume a request context, instead
+   * @see RequestContext
+   *
+   * @example
+   * // inside of a module
+   * // @Component()
+   * export class SomeClass { . . . }
+   * declare global {
+   *   interface RequestContextMembers {
+   *     someClass: SomeClass;
+   *   }
+   * }
+   */
+  // tslint:disable-next-line:no-empty-interface
+  interface RequestContextMembers {}
+}
+
+/**
+ * Type of the context object that will be provided to request-scoped methods
+ * managed by DI.
+ * @example
+ * // @route(. . .)
+ * handleRequest({ prizeRepository, prizeAuthorizationService }: RequestContext)
+ */
+export interface RequestContext
+  extends Assign<ApplicationContext, RequestContextMembers> {}
+
+/**
+ * Type of the request context container
+ */
+export interface RequestContainer extends ContextContainer<RequestContext> {}
+
+/**
+ * Type for overwriting T onto a request context.
+ */
+export type EnhancedRequestContext<T> = Assign<RequestContext, T> & {
+  container: ContextContainer<Assign<RequestContext, T>>;
+};

--- a/packages/api/src/config/context/WebserverContext.ts
+++ b/packages/api/src/config/context/WebserverContext.ts
@@ -1,12 +1,13 @@
-import { asFunction, AwilixContainer } from "awilix";
+import { asFunction } from "awilix";
 import * as Koa from "koa";
 export class WebserverContext {
   /**
    * @static @method configureContainer
    * Provide a webserver to the DI container.
    * @param container - The DI container
+   * @inject
    */
-  static configureContainer(container: AwilixContainer) {
+  static configureContainer({ container }: ApplicationContextMembers) {
     container.register(
       "webserver",
       asFunction(() => {

--- a/packages/api/src/config/context/WebserverContext.ts
+++ b/packages/api/src/config/context/WebserverContext.ts
@@ -19,7 +19,7 @@ export class WebserverContext {
 }
 
 declare global {
-  interface ApplicationContext {
+  interface ApplicationContextMembers {
     /** The Koa instance for the application */
     webserver: Koa;
   }

--- a/packages/api/src/config/context/WebserverContext.ts
+++ b/packages/api/src/config/context/WebserverContext.ts
@@ -17,3 +17,10 @@ export class WebserverContext {
     return container;
   }
 }
+
+declare global {
+  interface ApplicationContext {
+    /** The Koa instance for the application */
+    webserver: Koa;
+  }
+}

--- a/packages/api/src/config/env/EnvService.ts
+++ b/packages/api/src/config/env/EnvService.ts
@@ -48,7 +48,7 @@ export class EnvService {
    * Creates an EnvService with data poulated from the specified environment.
    * @param NODE_ENV - The runtime environment to use.
    */
-  constructor(NODE_ENV: Partial<ENV_VARS>) {
+  constructor({ NODE_ENV }: ApplicationContextMembers) {
     this.ormConfig = this.createOrmConfig(NODE_ENV);
     this.tokenConfig = this.createTokenConfig(NODE_ENV);
     this.webserverConfig = this.createWebserverConfig(NODE_ENV);

--- a/packages/api/src/config/env/EnvService.ts
+++ b/packages/api/src/config/env/EnvService.ts
@@ -47,6 +47,7 @@ export class EnvService {
   /**
    * Creates an EnvService with data poulated from the specified environment.
    * @param NODE_ENV - The runtime environment to use.
+   * @inject
    */
   constructor({ NODE_ENV }: ApplicationContextMembers) {
     this.ormConfig = this.createOrmConfig(NODE_ENV);

--- a/packages/api/src/controllers/RestRepositoryController.ts
+++ b/packages/api/src/controllers/RestRepositoryController.ts
@@ -205,6 +205,7 @@ export abstract class RestRepositoryController<T> {
    * @Route PATCH /entityPlural/{id}
    * @param id - Pathvariable, the ID of the entity to fetch.
    * @param requestBody
+   * @inject
    */
   async modifyOne({
     pathVariables: { id },

--- a/packages/api/src/controllers/RestRepositoryController.ts
+++ b/packages/api/src/controllers/RestRepositoryController.ts
@@ -1,5 +1,6 @@
 import { Connection, Repository } from "typeorm";
 import { RoleLiteral } from "../auth/RoleLiteral";
+import { bind } from "../AwilixHelpers";
 import { ApplicationContext } from "../config/context/ApplicationContext";
 import { RequestContext } from "../config/context/RequestContext";
 import { HttpMethod } from "../HttpMethod";
@@ -91,11 +92,10 @@ export abstract class RestRepositoryController<T> {
             e instanceof MethodNotSupportedError
           ) {
             // handler isn't covered, register it
-            const resolver = methodMap[method].fn.bind(this);
             routeRegistry.registerRoute(
               route,
               method,
-              resolver,
+              bind(methodMap[method].fn, this),
               this,
               methodMap[method].roles
             );

--- a/packages/api/src/controllers/RestRepositoryController.ts
+++ b/packages/api/src/controllers/RestRepositoryController.ts
@@ -1,10 +1,10 @@
-import { Context } from "koa";
 import { Connection, Repository } from "typeorm";
 import { RoleLiteral } from "../auth/RoleLiteral";
 import { asClassMethod } from "../AwilixHelpers";
+import { ApplicationContext } from "../config/context/ApplicationContext";
+import { RequestContext } from "../config/context/RequestContext";
 import { HttpMethod } from "../HttpMethod";
 import { MethodNotSupportedError } from "../web/MethodNotSupportedError";
-import { RouteRegistry } from "../web/RouteRegistry";
 import { UnknownRouteError } from "../web/UnknownRouteError";
 /**
  * Pluralize a given string.
@@ -57,8 +57,9 @@ export abstract class RestRepositoryController<T> {
    * Registers default fallback handlers for this repository if they are
    * not already registered.
    * @param routeRegistry The route registry to write to.
+   * @inject
    */
-  registerRoutes(routeRegistry: RouteRegistry) {
+  registerRoutes({ routeRegistry }: ApplicationContext) {
     const fallbackHandlers: IFallbackHandlerMap = {
       [this.listRoute]: {
         [HttpMethod.GET]: {
@@ -136,8 +137,9 @@ export abstract class RestRepositoryController<T> {
    * Handler for list-route POSTs
    * @Route POST /entityPlural
    * @param requestBody
+   * @inject
    */
-  async createOne(requestBody: any, ctx: Context): Promise<T> {
+  async createOne({ requestBody, ctx }: RequestContext): Promise<T> {
     const entity: T = this.repository.create();
     // TODO: massive security issues
     Object.keys(requestBody).forEach(key => {
@@ -156,11 +158,17 @@ export abstract class RestRepositoryController<T> {
    * Handler for detail-route PATCHes
    * @Route PATCH /entityPlural/{id}
    * @param id - The ID of the entity to delete.
+   * @inject
    */
-  async updateOne(id: string, requestBody: any, ctx: Context) {
+  async updateOne(context: RequestContext) {
+    const {
+      pathVariables: { id },
+      requestBody,
+      ctx
+    } = context;
     try {
-      await this.repository.update(id, requestBody);
-      return await this.getOne(id);
+      await this.repository.update(id, requestBody as any);
+      return await this.getOne(context);
     } catch (error) {
       ctx.status = 400;
       ctx.state.result = "";
@@ -172,8 +180,11 @@ export abstract class RestRepositoryController<T> {
    * Handler for detail-route DELETEs
    * @Route DELETE /entityPlural/{id}
    * @param id - The ID of the entity to delete.
+   * @inject
    */
-  async deleteOne(id: string): Promise<{ ok: boolean }> {
+  async deleteOne({
+    pathVariables: { id }
+  }: RequestContext): Promise<{ ok: boolean }> {
     await this.repository.delete(id);
     return { ok: true };
   }
@@ -182,9 +193,10 @@ export abstract class RestRepositoryController<T> {
    * Default handler for detail-route GETs
    * @Route POST /entityPlural/{id}
    * @param id - The ID of the entitity to fetch.
+   * @inject
    */
   // @Route("/entities/{id}", GET)
-  getOne(id: string): Promise<T> {
+  getOne({ pathVariables: { id } }: RequestContext): Promise<T> {
     return this.repository.findOne(id);
   }
 
@@ -194,7 +206,10 @@ export abstract class RestRepositoryController<T> {
    * @param id - Pathvariable, the ID of the entity to fetch.
    * @param requestBody
    */
-  async modifyOne(id: string, requestBody: any): Promise<T> {
+  async modifyOne({
+    pathVariables: { id },
+    requestBody
+  }: RequestContext): Promise<T> {
     const entity: T = await this.repository.findOne(id);
     if (!entity) {
       // TODO: 404?

--- a/packages/api/src/controllers/RestRepositoryController.ts
+++ b/packages/api/src/controllers/RestRepositoryController.ts
@@ -1,6 +1,5 @@
 import { Connection, Repository } from "typeorm";
 import { RoleLiteral } from "../auth/RoleLiteral";
-import { asClassMethod } from "../AwilixHelpers";
 import { ApplicationContext } from "../config/context/ApplicationContext";
 import { RequestContext } from "../config/context/RequestContext";
 import { HttpMethod } from "../HttpMethod";
@@ -92,7 +91,7 @@ export abstract class RestRepositoryController<T> {
             e instanceof MethodNotSupportedError
           ) {
             // handler isn't covered, register it
-            const resolver = asClassMethod(this, methodMap[method].fn);
+            const resolver = methodMap[method].fn.bind(this);
             routeRegistry.registerRoute(
               route,
               method,

--- a/packages/api/src/db/DbMetadataService.ts
+++ b/packages/api/src/db/DbMetadataService.ts
@@ -25,7 +25,7 @@ export class DbMetadataService {
 }
 
 declare global {
-  interface ApplicationContext {
+  interface ApplicationContextMembers {
     /** Service for interacting with typeorm database metadata. */
     dbMetadataService: DbMetadataService;
   }

--- a/packages/api/src/db/DbMetadataService.ts
+++ b/packages/api/src/db/DbMetadataService.ts
@@ -23,3 +23,10 @@ export class DbMetadataService {
       .map(c => c.propertyName) as any;
   }
 }
+
+declare global {
+  interface ApplicationContext {
+    /** Service for interacting with typeorm database metadata. */
+    dbMetadataService: DbMetadataService;
+  }
+}

--- a/packages/api/src/db/TransactionService.ts
+++ b/packages/api/src/db/TransactionService.ts
@@ -5,6 +5,11 @@ import { Component } from "../reflection/Component";
 @Component("SCOPED")
 export class TransactionService {
   constructor(private container: AwilixContainer) {}
+  /**
+   * Run a function in a transaction.
+   * @param fn - The function to execute, will be built with a DI container.
+   * @return The return value of `fn`
+   */
   async runTransaction(fn: (...args: any[]) => any) {
     const orm: Connection = this.container.cradle.orm;
     return await orm.transaction(async manager => {
@@ -12,5 +17,12 @@ export class TransactionService {
       transactionContainer.register("manager", asValue(manager));
       return await transactionContainer.build(fn);
     });
+  }
+}
+
+declare global {
+  interface ApplicationContext {
+    /** Service for running units of work in typeorm transactions. */
+    transactionService: TransactionService;
   }
 }

--- a/packages/api/src/db/TransactionService.ts
+++ b/packages/api/src/db/TransactionService.ts
@@ -1,10 +1,18 @@
-import { asValue, AwilixContainer } from "awilix";
+import { asValue } from "awilix";
 import { Connection } from "typeorm";
+import {
+  AnyContext,
+  ApplicationContainer
+} from "../config/context/ApplicationContext";
+import { RequestContainer } from "../config/context/RequestContext";
 import { Component } from "../reflection/Component";
 
 @Component("SCOPED")
 export class TransactionService {
-  constructor(private container: AwilixContainer) {}
+  private container: ApplicationContainer | RequestContainer;
+  constructor({ container }: AnyContext) {
+    this.container = container;
+  }
   /**
    * Run a function in a transaction.
    * @param fn - The function to execute, will be built with a DI container.

--- a/packages/api/src/db/TransactionService.ts
+++ b/packages/api/src/db/TransactionService.ts
@@ -21,7 +21,7 @@ export class TransactionService {
 }
 
 declare global {
-  interface ApplicationContext {
+  interface ApplicationContextMembers {
     /** Service for running units of work in typeorm transactions. */
     transactionService: TransactionService;
   }

--- a/packages/api/src/middlewares/AuthorizationMiddlewareFactory.ts
+++ b/packages/api/src/middlewares/AuthorizationMiddlewareFactory.ts
@@ -74,3 +74,9 @@ export class AuthorizationMiddlewareFactory implements IMiddlewareFactory {
     };
   }
 }
+
+declare global {
+  interface RequestContext {
+    user: User | undefined;
+  }
+}

--- a/packages/api/src/middlewares/AuthorizationMiddlewareFactory.ts
+++ b/packages/api/src/middlewares/AuthorizationMiddlewareFactory.ts
@@ -76,7 +76,7 @@ export class AuthorizationMiddlewareFactory implements IMiddlewareFactory {
 }
 
 declare global {
-  interface RequestContext {
+  interface RequestContextMembers {
     user: User | undefined;
   }
 }

--- a/packages/api/src/middlewares/AuthorizationMiddlewareFactory.ts
+++ b/packages/api/src/middlewares/AuthorizationMiddlewareFactory.ts
@@ -1,10 +1,12 @@
-import { asValue, AwilixContainer } from "awilix";
+import { asValue } from "awilix";
 import { Context, Middleware } from "koa";
 import { Repository } from "typeorm";
 import { AuthenticationService } from "../auth/AuthenticationService";
 import { hasRole } from "../auth/AuthHelpers";
 import { PermissionDeniedError } from "../auth/PermissionDeniedError";
 import { RoleLiteral } from "../auth/RoleLiteral";
+import { ApplicationContext } from "../config/context/ApplicationContext";
+import { RequestContainer } from "../config/context/RequestContext";
 import { getMethod } from "../HttpMethod";
 import { User } from "../models";
 import { RouteRegistry } from "../web/RouteRegistry";
@@ -15,15 +17,23 @@ import { IMiddlewareFactory } from "./IMiddlewareFactory";
  * request. Attaches the current user to request-scoped DI container as "user".
  */
 export class AuthorizationMiddlewareFactory implements IMiddlewareFactory {
-  constructor(
-    private userRepository: Repository<User>,
-    private routeRegistry: RouteRegistry,
-    private authenticationService: AuthenticationService
-  ) {}
+  userRepository: Repository<User>;
+  routeRegistry: RouteRegistry;
+  authenticationService: AuthenticationService;
+  /** @inject */
+  constructor({
+    userRepository,
+    routeRegistry,
+    authenticationService
+  }: ApplicationContext) {
+    this.userRepository = userRepository;
+    this.routeRegistry = routeRegistry;
+    this.authenticationService = authenticationService;
+  }
   create(): Middleware {
     return async (ctx: Context, next: () => Promise<any>) => {
       const { path, method } = ctx;
-      const requestContainer: AwilixContainer = ctx.state.requestContainer;
+      const requestContainer: RequestContainer = ctx.state.requestContainer;
       let allowedRoles: RoleLiteral[];
       try {
         allowedRoles = this.routeRegistry.lookupRoute(path, getMethod(method))

--- a/packages/api/src/middlewares/ErrorHandlerMiddlewareFactory.ts
+++ b/packages/api/src/middlewares/ErrorHandlerMiddlewareFactory.ts
@@ -17,6 +17,13 @@ import { IMiddlewareFactory } from "./IMiddlewareFactory";
 import { INextCallback } from "./INextCallback";
 
 export class ErrorHandlerMiddlewareFactory implements IMiddlewareFactory {
+  /**
+   * @inject
+   */
+  constructor() {
+    // empty
+  }
+
   create = () => async (ctx: Context, next: INextCallback) => {
     try {
       await next();

--- a/packages/api/src/middlewares/RequestContainerMiddlewareFactory.ts
+++ b/packages/api/src/middlewares/RequestContainerMiddlewareFactory.ts
@@ -31,3 +31,10 @@ export class RequestContainerMiddlewareFactory implements IMiddlewareFactory {
     await next();
   };
 }
+
+declare global {
+  interface RequestContext {
+    ctx: Context;
+    query: any;
+  }
+}

--- a/packages/api/src/middlewares/RequestContainerMiddlewareFactory.ts
+++ b/packages/api/src/middlewares/RequestContainerMiddlewareFactory.ts
@@ -42,8 +42,11 @@ export class RequestContainerMiddlewareFactory implements IMiddlewareFactory {
 
 declare global {
   interface RequestContextMembers {
+    /** Request-scoped DI container */
     container: RequestContainer;
+    /** The Koa context for this request */
     ctx: Context;
+    /** The parsed querystring (key-value pair hash) */
     query: any;
   }
 }

--- a/packages/api/src/middlewares/RequestContainerMiddlewareFactory.ts
+++ b/packages/api/src/middlewares/RequestContainerMiddlewareFactory.ts
@@ -33,7 +33,8 @@ export class RequestContainerMiddlewareFactory implements IMiddlewareFactory {
 }
 
 declare global {
-  interface RequestContext {
+  interface RequestContextMembers {
+    container: RequestContainer;
     ctx: Context;
     query: any;
   }

--- a/packages/api/src/middlewares/RequestContainerMiddlewareFactory.ts
+++ b/packages/api/src/middlewares/RequestContainerMiddlewareFactory.ts
@@ -1,5 +1,10 @@
-import { asValue, AwilixContainer } from "awilix";
+import { asValue } from "awilix";
 import { Context } from "koa";
+import {
+  ApplicationContainer,
+  ApplicationContext
+} from "../config/context/ApplicationContext";
+import { RequestContainer } from "../config/context/RequestContext";
 import { RequestParsingService } from "../config/RequestParsingService";
 import { IMiddlewareFactory } from "./IMiddlewareFactory";
 import { INextCallback } from "./INextCallback";
@@ -15,12 +20,15 @@ import { INextCallback } from "./INextCallback";
  *  from the parent scope with a request-scoped container.
  */
 export class RequestContainerMiddlewareFactory implements IMiddlewareFactory {
-  constructor(
-    private container: AwilixContainer,
-    private requestParsingService: RequestParsingService
-  ) {}
+  private requestParsingService: RequestParsingService;
+  private container: ApplicationContainer;
+  /** @inject */
+  constructor({ container, requestParsingService }: ApplicationContext) {
+    this.container = container;
+    this.requestParsingService = requestParsingService;
+  }
   create = () => async (ctx: Context, next: INextCallback) => {
-    const requestContainer: AwilixContainer = this.container.createScope();
+    const requestContainer = this.container.createScope<RequestContainer>();
     // register the context
     requestContainer.register("ctx", asValue(ctx));
     requestContainer.register("container", asValue(requestContainer));

--- a/packages/api/src/middlewares/RouterMiddlewareFactory.ts
+++ b/packages/api/src/middlewares/RouterMiddlewareFactory.ts
@@ -1,6 +1,5 @@
 import { asValue } from "awilix";
 import { Context, Middleware } from "koa";
-import { asClassMethod } from "../AwilixHelpers";
 import { ApplicationContext } from "../config/context/ApplicationContext";
 import {
   RequestContainer,
@@ -53,7 +52,7 @@ export class RouterMiddlewareFactory implements IMiddlewareFactory {
       // TODO: this could be a typeguard
       if (router && typeof router.configureRequestContainer === "function") {
         await requestContainer.build(
-          asClassMethod(router, router.configureRequestContainer)
+          router.configureRequestContainer.bind(router)
         );
       }
       // Invoke this route's handler, and store its response on the context

--- a/packages/api/src/middlewares/RouterMiddlewareFactory.ts
+++ b/packages/api/src/middlewares/RouterMiddlewareFactory.ts
@@ -71,19 +71,22 @@ export class RouterMiddlewareFactory implements IMiddlewareFactory {
  */
 function registerPathVariables(
   pathVariables: { [key: string]: string },
-  requestContainer: AwilixContainer
+  requestContainer: RequestContainer
 ) {
   requestContainer.register("pathVariables", asValue(pathVariables || {}));
   if (!pathVariables) {
     return;
   }
   for (const variable of Object.keys(pathVariables)) {
-    requestContainer.register(variable, asValue(pathVariables[variable]));
+    requestContainer.register(
+      variable as keyof RequestContext,
+      asValue(pathVariables[variable])
+    );
   }
 }
 
 declare global {
-  interface RequestContext {
+  interface RequestContextMembers {
     pathVariables: { [pathVariable: string]: string | undefined };
   }
 }

--- a/packages/api/src/middlewares/RouterMiddlewareFactory.ts
+++ b/packages/api/src/middlewares/RouterMiddlewareFactory.ts
@@ -1,5 +1,6 @@
 import { asValue } from "awilix";
 import { Context, Middleware } from "koa";
+import { bind } from "../AwilixHelpers";
 import { ApplicationContext } from "../config/context/ApplicationContext";
 import {
   RequestContainer,
@@ -52,7 +53,7 @@ export class RouterMiddlewareFactory implements IMiddlewareFactory {
       // TODO: this could be a typeguard
       if (router && typeof router.configureRequestContainer === "function") {
         await requestContainer.build(
-          router.configureRequestContainer.bind(router)
+          bind(router.configureRequestContainer, router)
         );
       }
       // Invoke this route's handler, and store its response on the context

--- a/packages/api/src/middlewares/RouterMiddlewareFactory.ts
+++ b/packages/api/src/middlewares/RouterMiddlewareFactory.ts
@@ -1,6 +1,11 @@
-import { asValue, AwilixContainer } from "awilix";
+import { asValue } from "awilix";
 import { Context, Middleware } from "koa";
 import { asClassMethod } from "../AwilixHelpers";
+import { ApplicationContext } from "../config/context/ApplicationContext";
+import {
+  RequestContainer,
+  RequestContext
+} from "../config/context/RequestContext";
 import { getMethod, HttpMethod } from "../HttpMethod";
 import { RouteRegistry } from "../web/RouteRegistry";
 import { UnknownMethodError } from "../web/UnknownMethodError";
@@ -14,10 +19,14 @@ import { INextCallback } from "./INextCallback";
  * Depends on ctx.state.requestContainer being set.
  */
 export class RouterMiddlewareFactory implements IMiddlewareFactory {
+  private routeRegistry: RouteRegistry;
   /**
    * @param routeRegistry - The route registry to use when mapping requests.
+   * @inject
    */
-  constructor(private routeRegistry: RouteRegistry) {}
+  constructor({ routeRegistry }: ApplicationContext) {
+    this.routeRegistry = routeRegistry;
+  }
   /**
    * Create the router middleware.
    */
@@ -33,7 +42,7 @@ export class RouterMiddlewareFactory implements IMiddlewareFactory {
       if (!ctx.state.requestContainer) {
         throw new Error("No request container available.");
       }
-      const requestContainer: AwilixContainer = ctx.state.requestContainer;
+      const requestContainer: RequestContainer = ctx.state.requestContainer;
 
       const {
         router,

--- a/packages/api/src/middlewares/RouterMiddlewareFactory.ts
+++ b/packages/api/src/middlewares/RouterMiddlewareFactory.ts
@@ -81,3 +81,9 @@ function registerPathVariables(
     requestContainer.register(variable, asValue(pathVariables[variable]));
   }
 }
+
+declare global {
+  interface RequestContext {
+    pathVariables: { [pathVariable: string]: string | undefined };
+  }
+}

--- a/packages/api/src/models/DrawEvent/DrawController.ts
+++ b/packages/api/src/models/DrawEvent/DrawController.ts
@@ -1,6 +1,5 @@
 import { RequestContext } from "../../config/context/RequestContext";
 import { HttpMethod } from "../../HttpMethod";
-import { logger } from "../../logging";
 import { selectRandomItemFromPool } from "../../RandomUtils";
 import { Component } from "../../reflection/Component";
 import { Route } from "../../reflection/Route";
@@ -71,6 +70,7 @@ export class DrawController {
     let drawEvent: DrawEvent;
     // run all of this in a transaction so it's all nice and atomic
     return await transactionService.runTransaction(
+      /** @inject */
       async ({ prizeRepository, drawEventRepository }: RequestContext) => {
         // TODO: This could be done better. Basically to prevent wasting a DB lock
         // this check is duplicated here.

--- a/packages/api/src/models/DrawEvent/DrawEventAuthorizationService.ts
+++ b/packages/api/src/models/DrawEvent/DrawEventAuthorizationService.ts
@@ -128,3 +128,10 @@ export class DrawEventAuthorizationService {
 
 // tslint:disable-next-line no-empty-interface
 export interface DrawEventAuthorizationService extends ContainerAware {}
+
+declare global {
+  interface ApplicationContext {
+    /** Service for authenticating actions on DrawEvent models */
+    drawEventAuthorizationService: DrawEventAuthorizationService;
+  }
+}

--- a/packages/api/src/models/DrawEvent/DrawEventAuthorizationService.ts
+++ b/packages/api/src/models/DrawEvent/DrawEventAuthorizationService.ts
@@ -130,7 +130,7 @@ export class DrawEventAuthorizationService {
 export interface DrawEventAuthorizationService extends ContainerAware {}
 
 declare global {
-  interface ApplicationContext {
+  interface ApplicationContextMembers {
     /** Service for authenticating actions on DrawEvent models */
     drawEventAuthorizationService: DrawEventAuthorizationService;
   }

--- a/packages/api/src/models/DrawEvent/DrawEventAuthorizationService.ts
+++ b/packages/api/src/models/DrawEvent/DrawEventAuthorizationService.ts
@@ -14,6 +14,7 @@ import { DrawRateLimitExceededError } from "./DrawRateLimitExceededError";
 @Component()
 @MakeContainerAware()
 export class DrawEventAuthorizationService {
+  /** @inject */
   constructor({ container }: RequestContext) {
     this.container = container;
   }

--- a/packages/api/src/models/DrawEvent/DrawEventAuthorizationService.ts
+++ b/packages/api/src/models/DrawEvent/DrawEventAuthorizationService.ts
@@ -1,10 +1,10 @@
 import { PartialExcept } from "@clovercoin/constants";
-import { AwilixContainer } from "awilix";
 import { addSeconds, differenceInSeconds } from "date-fns";
-import { Connection, EntityManager, FindManyOptions } from "typeorm";
+import { FindManyOptions } from "typeorm";
 import { hasRole } from "../../auth/AuthHelpers";
 import { PermissionDeniedError } from "../../auth/PermissionDeniedError";
 import { ContainerAware, MakeContainerAware } from "../../AwilixHelpers";
+import { RequestContext } from "../../config/context/RequestContext";
 import { Component } from "../../reflection/Component";
 import { getCurrentTime } from "../../TimeUtils";
 import { DrawEvent } from "../DrawEvent";
@@ -14,7 +14,9 @@ import { DrawRateLimitExceededError } from "./DrawRateLimitExceededError";
 @Component()
 @MakeContainerAware()
 export class DrawEventAuthorizationService {
-  constructor(public container: AwilixContainer) {}
+  constructor({ container }: RequestContext) {
+    this.container = container;
+  }
 
   /**
    * Determine if a user may create a new draw event.
@@ -26,7 +28,8 @@ export class DrawEventAuthorizationService {
   get canCreate() {
     return this.buildMethod(this.buildCanCreate);
   }
-  private buildCanCreate(user: User, orm: Connection | EntityManager) {
+  /** @inject */
+  private buildCanCreate({ user, orm }: RequestContext) {
     return async (createEvent: PartialExcept<DrawEvent, "user" | "game">) => {
       if (!hasRole(user, "user")) {
         throw new PermissionDeniedError();
@@ -40,6 +43,7 @@ export class DrawEventAuthorizationService {
       }
       const drawEventRepository = orm.getCustomRepository(DrawEventRepository);
       // draws must be separated by 30 seconds
+      // TODO: draws must be separated by the configured game time not 30 seconds
       const lastDraw = await drawEventRepository.getLastDrawEvent(
         user,
         createEvent.game
@@ -68,7 +72,8 @@ export class DrawEventAuthorizationService {
   get canReadMultiple() {
     return this.buildMethod(this.buildCanReadMultiple);
   }
-  buildCanReadMultiple(user: User) {
+  /** @inject */
+  buildCanReadMultiple({ user }: RequestContext) {
     const contextUser = user;
     return (
       findOptions: FindManyOptions<DrawEvent>,

--- a/packages/api/src/models/DrawEvent/DrawEventRepository.ts
+++ b/packages/api/src/models/DrawEvent/DrawEventRepository.ts
@@ -38,7 +38,7 @@ export class DrawEventRepository extends Repository<DrawEvent> {
 }
 
 declare global {
-  interface ApplicationContext {
+  interface ApplicationContextMembers {
     /** Repository for managing draw events */
     drawEventRepository: DrawEventRepository;
   }

--- a/packages/api/src/models/DrawEvent/DrawEventRepository.ts
+++ b/packages/api/src/models/DrawEvent/DrawEventRepository.ts
@@ -36,3 +36,10 @@ export class DrawEventRepository extends Repository<DrawEvent> {
     return result[0];
   }
 }
+
+declare global {
+  interface ApplicationContext {
+    /** Repository for managing draw events */
+    drawEventRepository: DrawEventRepository;
+  }
+}

--- a/packages/api/src/models/Prize.ts
+++ b/packages/api/src/models/Prize.ts
@@ -45,4 +45,8 @@ export class Prize {
   drawEvents: DrawEvent[];
 }
 
+/** These fields are excluded from most requests and must be explicitly added.
+ * Intended for internal/admin use only, as sensitive information is contained
+ * here
+ */
 export const prizeAdminFields = ["weight", "currentStock", "initialStock"];

--- a/packages/api/src/models/Prize.ts
+++ b/packages/api/src/models/Prize.ts
@@ -44,3 +44,5 @@ export class Prize {
   @OneToMany(type => DrawEvent, drawEvent => drawEvent.prize, { eager: false })
   drawEvents: DrawEvent[];
 }
+
+export const prizeAdminFields = ["weight", "currentStock", "initialStock"];

--- a/packages/api/src/models/Role.ts
+++ b/packages/api/src/models/Role.ts
@@ -1,5 +1,5 @@
 import { ROLES } from "@clovercoin/constants";
-import { Column, Entity, PrimaryGeneratedColumn, Repository } from "typeorm";
+import { Column, Entity, PrimaryGeneratedColumn } from "typeorm";
 import { isDuplicateKeyError } from "../db/OrmErrors";
 
 @Entity()
@@ -14,7 +14,7 @@ export class Role {
    * @param roleRepository - The role repository to use when creating initial
    *    roles.
    */
-  static async createInitialEntities(roleRepository: Repository<Role>) {
+  static async createInitialEntities({ roleRepository }: ApplicationContextMembers) {
     const requiredRoleNames = ROLES;
     for (const [, roleName] of Object.entries(requiredRoleNames)) {
       const role = roleRepository.create();

--- a/packages/api/src/models/Role.ts
+++ b/packages/api/src/models/Role.ts
@@ -1,5 +1,6 @@
 import { ROLES } from "@clovercoin/constants";
 import { Column, Entity, PrimaryGeneratedColumn } from "typeorm";
+import { ApplicationContext } from "../config/context/ApplicationContext";
 import { isDuplicateKeyError } from "../db/OrmErrors";
 
 @Entity()
@@ -13,8 +14,9 @@ export class Role {
    * configuration.
    * @param roleRepository - The role repository to use when creating initial
    *    roles.
+   * @inject
    */
-  static async createInitialEntities({ roleRepository }: ApplicationContextMembers) {
+  static async createInitialEntities({ roleRepository }: ApplicationContext) {
     const requiredRoleNames = ROLES;
     for (const [, roleName] of Object.entries(requiredRoleNames)) {
       const role = roleRepository.create();

--- a/packages/api/src/models/game/GameAuthorizationService.ts
+++ b/packages/api/src/models/game/GameAuthorizationService.ts
@@ -1,6 +1,5 @@
 import { hasRole } from "../../auth/AuthHelpers";
 import { PermissionDeniedError } from "../../auth/PermissionDeniedError";
-import { asClassMethod } from "../../AwilixHelpers";
 import {
   AnyContext,
   ApplicationContainer
@@ -34,7 +33,8 @@ export class GameAuthorizationService {
     }
   }
   get canRead() {
-    return this.container.build(asClassMethod(this, this.authCanRead));
+    const authCanRead = this.authCanRead;
+    return this.container.build(authCanRead.bind(this) as typeof authCanRead);
   }
   /** @inject */
   private authCanRead({ user }: RequestContext) {

--- a/packages/api/src/models/game/GameAuthorizationService.ts
+++ b/packages/api/src/models/game/GameAuthorizationService.ts
@@ -38,3 +38,10 @@ export class GameAuthorizationService {
     };
   }
 }
+
+declare global {
+  interface ApplicationContext {
+    /** Service for authenticating actions on Game models */
+    gameAuthorizationService: GameAuthorizationService;
+  }
+}

--- a/packages/api/src/models/game/GameAuthorizationService.ts
+++ b/packages/api/src/models/game/GameAuthorizationService.ts
@@ -40,7 +40,7 @@ export class GameAuthorizationService {
 }
 
 declare global {
-  interface ApplicationContext {
+  interface ApplicationContextMembers {
     /** Service for authenticating actions on Game models */
     gameAuthorizationService: GameAuthorizationService;
   }

--- a/packages/api/src/models/game/GameAuthorizationService.ts
+++ b/packages/api/src/models/game/GameAuthorizationService.ts
@@ -1,5 +1,6 @@
 import { hasRole } from "../../auth/AuthHelpers";
 import { PermissionDeniedError } from "../../auth/PermissionDeniedError";
+import { bind } from "../../AwilixHelpers";
 import {
   AnyContext,
   ApplicationContainer
@@ -34,7 +35,7 @@ export class GameAuthorizationService {
   }
   get canRead() {
     const authCanRead = this.authCanRead;
-    return this.container.build(authCanRead.bind(this) as typeof authCanRead);
+    return this.container.build(bind(authCanRead, this));
   }
   /** @inject */
   private authCanRead({ user }: RequestContext) {

--- a/packages/api/src/models/game/GameAuthorizationService.ts
+++ b/packages/api/src/models/game/GameAuthorizationService.ts
@@ -1,14 +1,22 @@
-import { AwilixContainer } from "awilix";
 import { hasRole } from "../../auth/AuthHelpers";
 import { PermissionDeniedError } from "../../auth/PermissionDeniedError";
 import { asClassMethod } from "../../AwilixHelpers";
+import {
+  AnyContext,
+  ApplicationContainer
+} from "../../config/context/ApplicationContext";
+import { RequestContext } from "../../config/context/RequestContext";
 import { Component } from "../../reflection/Component";
 import { Game } from "../Game";
 import { User } from "../User";
 
 @Component("TRANSIENT")
 export class GameAuthorizationService {
-  constructor(public container: AwilixContainer) {}
+  container: ApplicationContainer;
+  /** @inject */
+  constructor({ container }: AnyContext) {
+    this.container = container;
+  }
   async canCreate(user: User) {
     if (!hasRole(user, "admin")) {
       throw new PermissionDeniedError();
@@ -28,7 +36,8 @@ export class GameAuthorizationService {
   get canRead() {
     return this.container.build(asClassMethod(this, this.authCanRead));
   }
-  private authCanRead(user: User) {
+  /** @inject */
+  private authCanRead({ user }: RequestContext) {
     const containerUser = user;
     return async (game: Game, user: User = containerUser) => {
       if (!hasRole(user, "user")) {

--- a/packages/api/src/models/index.ts
+++ b/packages/api/src/models/index.ts
@@ -19,7 +19,7 @@ export interface IModelClass<T = any> {
 export const MODELS: IModelClass[] = [User, Prize, Role, DrawEvent, Game];
 
 declare global {
-  interface ApplicationContext {
+  interface ApplicationContextMembers {
     // see OrmContext for creation of these default repositories
     // if a custom repository is created for any model in this list,
     // remove it from here and declare its more specific type in the

--- a/packages/api/src/models/index.ts
+++ b/packages/api/src/models/index.ts
@@ -6,6 +6,7 @@ import { Role } from "./Role";
 import { User } from "./User";
 export { DrawEvent } from "./DrawEvent";
 export { User } from "./User";
+import { Repository } from "typeorm";
 import { Game } from "./Game";
 export { Game } from "./Game";
 /**
@@ -16,3 +17,15 @@ export interface IModelClass<T = any> {
   new (...args: any[]): T;
 }
 export const MODELS: IModelClass[] = [User, Prize, Role, DrawEvent, Game];
+
+declare global {
+  interface ApplicationContext {
+    // see OrmContext for creation of these default repositories
+    // if a custom repository is created for any model in this list,
+    // remove it from here and declare its more specific type in the
+    // implementation file
+    userRepository: Repository<User>;
+    roleRepository: Repository<Role>;
+    gameRepository: Repository<Game>;
+  }
+}

--- a/packages/api/src/models/prize/PrizeAuthorizationService.ts
+++ b/packages/api/src/models/prize/PrizeAuthorizationService.ts
@@ -129,3 +129,10 @@ export class PrizeAuthorizationService {
 }
 // tslint:disable-next-line no-empty-interface
 export interface PrizeAuthorizationService extends ContainerAware {}
+
+declare global {
+  interface ApplicationContext {
+    /** Service for authenticating actions on Prize models */
+    prizeAuthorizationService: PrizeAuthorizationService;
+  }
+}

--- a/packages/api/src/models/prize/PrizeAuthorizationService.ts
+++ b/packages/api/src/models/prize/PrizeAuthorizationService.ts
@@ -2,6 +2,10 @@ import { FindManyOptions } from "typeorm";
 import { hasRole } from "../../auth/AuthHelpers";
 import { PermissionDeniedError } from "../../auth/PermissionDeniedError";
 import { ContainerAware, MakeContainerAware } from "../../AwilixHelpers";
+import {
+  RequestContainer,
+  RequestContext
+} from "../../config/context/RequestContext";
 import { Component } from "../../reflection/Component";
 import { Prize } from "../Prize";
 import { User } from "../User";
@@ -9,6 +13,10 @@ import { User } from "../User";
 @Component("TRANSIENT")
 @MakeContainerAware()
 export class PrizeAuthorizationService {
+  container: RequestContainer;
+  constructor({ container }: RequestContext) {
+    this.container = container;
+  }
   /**
    * Determine if the user may read multiple prizes.
    * @param query - The find options that will be used to query for multiple
@@ -21,7 +29,8 @@ export class PrizeAuthorizationService {
   get canReadMultiple() {
     return this.buildMethod(this.buildCanReadMultiple);
   }
-  private buildCanReadMultiple(user: User) {
+  /** @inject */
+  private buildCanReadMultiple({ user }: RequestContext) {
     const containerUser = user;
     return async (query: FindManyOptions<Prize>, user = containerUser) => {
       if (
@@ -50,7 +59,8 @@ export class PrizeAuthorizationService {
   get canCreate() {
     return this.buildMethod(this.buildCanCreate);
   }
-  private buildCanCreate(user: User) {
+  /** @inject */
+  private buildCanCreate({ user }: RequestContext) {
     const containerUser = user;
     return async (prize: Prize, user: User = containerUser) => {
       if (!hasRole(user, "admin")) {
@@ -69,7 +79,8 @@ export class PrizeAuthorizationService {
   get canRead() {
     return this.buildMethod(this.buildCanRead);
   }
-  private buildCanRead(user: User) {
+  /** @inject */
+  private buildCanRead({ user }: RequestContext) {
     // TODO: This should be limiting users down by game and prize history.
     const containerUser = user;
     return (user: User = containerUser) => {
@@ -89,7 +100,8 @@ export class PrizeAuthorizationService {
   get canUpdate() {
     return this.buildMethod(this.buildCanUpdate);
   }
-  private buildCanUpdate(user: User) {
+  /** @inject */
+  private buildCanUpdate({ user }: RequestContext) {
     const containerUser = user;
     return (
       prize: Prize,
@@ -117,7 +129,8 @@ export class PrizeAuthorizationService {
   get canDelete() {
     return this.buildMethod(this.buildCanDelete);
   }
-  private buildCanDelete(user: User) {
+  /** @inject */
+  private buildCanDelete({ user }: RequestContext) {
     // TODO: Needs to recognize roles-per-game once that's a thing. . .
     const containerUser = user;
     return async (prize: Prize, user = containerUser) => {

--- a/packages/api/src/models/prize/PrizeAuthorizationService.ts
+++ b/packages/api/src/models/prize/PrizeAuthorizationService.ts
@@ -131,7 +131,7 @@ export class PrizeAuthorizationService {
 export interface PrizeAuthorizationService extends ContainerAware {}
 
 declare global {
-  interface ApplicationContext {
+  interface ApplicationContextMembers {
     /** Service for authenticating actions on Prize models */
     prizeAuthorizationService: PrizeAuthorizationService;
   }

--- a/packages/api/src/models/prize/PrizeController.ts
+++ b/packages/api/src/models/prize/PrizeController.ts
@@ -2,6 +2,7 @@ import { PartialKeys } from "@clovercoin/constants";
 import { asValue } from "awilix";
 import { FindManyOptions, FindOneOptions } from "typeorm";
 import { hasRole } from "../../auth/AuthHelpers";
+import { bind } from "../../AwilixHelpers";
 import { EnhancedRequestContext } from "../../config/context/RequestContext";
 import {
   validateRequest,
@@ -46,7 +47,7 @@ export abstract class PrizeController {
    */
   async configureRequestContainer({ container }: PrizeRequestContext) {
     const build = (fn: (...args: any[]) => any) =>
-      container.build(fn.bind(this));
+      container.build(bind(fn, this));
     await build(this.validatePrizeId);
     return await Promise.all([
       build(this.registerGame),

--- a/packages/api/src/models/prize/PrizeController.ts
+++ b/packages/api/src/models/prize/PrizeController.ts
@@ -71,9 +71,7 @@ export abstract class PrizeController {
       // these fields should never be given to normal users.
       options.select = [
         ...dbMetadataService.getDefaultSelect(Prize),
-        "weight",
-        "currentStock",
-        "initialStock"
+        ...prizeAdminFields
       ] as any;
     }
     container.register("prizeOptions", asValue(options));

--- a/packages/api/src/models/prize/PrizeController.ts
+++ b/packages/api/src/models/prize/PrizeController.ts
@@ -43,6 +43,7 @@ export abstract class PrizeController {
    * @configures {FindOptions<Prize> & FindManyOptions<Prize>} prizeOptions -
    *  the find options for the prize specified in the request.
    * @configures {Game} game - The game specified in the request.
+   * @inject
    */
   async configureRequestContainer({ container }: PrizeRequestContext) {
     const build = (fn: (...args: any[]) => any) =>

--- a/packages/api/src/models/prize/PrizeController.ts
+++ b/packages/api/src/models/prize/PrizeController.ts
@@ -1,19 +1,32 @@
 import { PartialKeys } from "@clovercoin/constants";
-import { asValue, AwilixContainer } from "awilix";
-import { FindManyOptions, FindOneOptions, Repository } from "typeorm";
+import { asValue } from "awilix";
+import { FindManyOptions, FindOneOptions } from "typeorm";
 import { hasRole } from "../../auth/AuthHelpers";
 import { asClassMethod } from "../../AwilixHelpers";
-import { DbMetadataService } from "../../db/DbMetadataService";
+import { EnhancedRequestContext } from "../../config/context/RequestContext";
 import {
   validateRequest,
   validateValue,
   validators
 } from "../../web/RequestValidationUtils";
 import { Game } from "../Game";
-import { Prize } from "../Prize";
-import { User } from "../User";
+import { Prize, prizeAdminFields } from "../Prize";
 
 type Options = FindOneOptions<Prize> | FindManyOptions<Prize>;
+
+/**
+ * Interface for augmented
+ */
+export interface PrizeRequestAugment {
+  prizeOptions: Options;
+  game: Game;
+}
+
+/**
+ * Type for the request context after augmentation by this controller.
+ */
+export interface PrizeRequestContext
+  extends EnhancedRequestContext<PrizeRequestAugment> {}
 
 /**
  * Base controller class for managing prizes. Contains logic for parsing
@@ -31,7 +44,7 @@ export abstract class PrizeController {
    *  the find options for the prize specified in the request.
    * @configures {Game} game - The game specified in the request.
    */
-  async configureRequestContainer(container: AwilixContainer) {
+  async configureRequestContainer({ container }: PrizeRequestContext) {
     const build = (fn: (...args: any[]) => any) =>
       container.build(asClassMethod(this, fn));
     await build(this.validatePrizeId);
@@ -46,15 +59,15 @@ export abstract class PrizeController {
    * include_config request variable for administrative users. Expects prizeId
    * to have already been validated.
    * @configures prizeOptions
+   * @inject
    */
-  registerFindPrizeOptions(
-    container: AwilixContainer,
-    query: any,
-    user: User,
-    gameId: string,
-    dbMetadataService: DbMetadataService
-  ) {
-    const prizeId = container.resolve("prizeId", { allowUnregistered: true });
+  registerFindPrizeOptions({
+    container,
+    query,
+    user,
+    pathVariables: { gameId, prizeId },
+    dbMetadataService
+  }: PrizeRequestContext) {
     const options: Options = {
       where: {
         game: gameId
@@ -80,10 +93,7 @@ export abstract class PrizeController {
   /**
    * Validate incoming {prizeId} from the request.
    */
-  validatePrizeId(container: AwilixContainer) {
-    const prizeId: string = container.resolve("prizeId", {
-      allowUnregistered: true
-    });
+  validatePrizeId({ pathVariables: { prizeId } }: PrizeRequestContext) {
     validateValue(prizeId, "prizeId", validators.optional.digitString);
   }
 
@@ -91,12 +101,13 @@ export abstract class PrizeController {
    * Validate {gameId} from the url, fetch the associated Game, and register
    * it as "game".
    * @configures game
+   * @inject
    */
-  async registerGame(
-    container: AwilixContainer,
-    gameRepository: Repository<Game>
-  ) {
-    const gameId = container.resolve("gameId", { allowUnregistered: true });
+  async registerGame({
+    container,
+    gameRepository,
+    pathVariables: { gameId }
+  }: PrizeRequestContext) {
     validateValue(gameId, "gameId", validators.digitString);
     const game = await gameRepository.findOneOrFail(gameId, {
       loadRelationIds: true

--- a/packages/api/src/models/prize/PrizeController.ts
+++ b/packages/api/src/models/prize/PrizeController.ts
@@ -2,7 +2,6 @@ import { PartialKeys } from "@clovercoin/constants";
 import { asValue } from "awilix";
 import { FindManyOptions, FindOneOptions } from "typeorm";
 import { hasRole } from "../../auth/AuthHelpers";
-import { asClassMethod } from "../../AwilixHelpers";
 import { EnhancedRequestContext } from "../../config/context/RequestContext";
 import {
   validateRequest,
@@ -47,7 +46,7 @@ export abstract class PrizeController {
    */
   async configureRequestContainer({ container }: PrizeRequestContext) {
     const build = (fn: (...args: any[]) => any) =>
-      container.build(asClassMethod(this, fn));
+      container.build(fn.bind(this));
     await build(this.validatePrizeId);
     return await Promise.all([
       build(this.registerGame),

--- a/packages/api/src/models/prize/PrizeDetailController.ts
+++ b/packages/api/src/models/prize/PrizeDetailController.ts
@@ -1,11 +1,8 @@
-import { FindOneOptions } from "typeorm";
 import { HttpMethod } from "../../HttpMethod";
 import { Controller } from "../../reflection/Controller";
 import { Route } from "../../reflection/Route";
 import { Prize } from "../Prize";
-import { PrizeAuthorizationService } from "./PrizeAuthorizationService";
-import { PrizeController } from "./PrizeController";
-import { PrizeRepository } from "./PrizeRepository";
+import { PrizeController, PrizeRequestContext } from "./PrizeController";
 /**
  * Controller for prize detail-route methods.
  */
@@ -19,11 +16,11 @@ export class PrizeDetailController extends PrizeController {
     method: HttpMethod.GET,
     roles: ["user"]
   })
-  async getPrize(
-    prizeOptions: FindOneOptions<Prize>,
-    prizeAuthorizationService: PrizeAuthorizationService,
-    prizeRepository: PrizeRepository
-  ): Promise<Prize> {
+  async getPrize({
+    prizeOptions,
+    prizeAuthorizationService,
+    prizeRepository
+  }: PrizeRequestContext): Promise<Prize> {
     const prize = await prizeRepository.findOneOrFail(prizeOptions);
     await prizeAuthorizationService.canRead();
     return prize;
@@ -37,12 +34,12 @@ export class PrizeDetailController extends PrizeController {
     method: HttpMethod.PATCH,
     roles: ["admin"]
   })
-  async updatePrize(
-    prizeOptions: FindOneOptions<Prize>,
-    requestBody: any,
-    prizeRepository: PrizeRepository,
-    prizeAuthorizationService: PrizeAuthorizationService
-  ) {
+  async updatePrize({
+    prizeOptions,
+    requestBody,
+    prizeRepository,
+    prizeAuthorizationService
+  }: PrizeRequestContext) {
     const prize = await prizeRepository.findOneOrFail(prizeOptions);
     const body = this.parseBodyForUpdate(requestBody);
     await prizeAuthorizationService.canUpdate(prize, body);
@@ -59,11 +56,11 @@ export class PrizeDetailController extends PrizeController {
     method: HttpMethod.DELETE,
     roles: ["admin"]
   })
-  async deletePrize(
-    prizeOptions: FindOneOptions<Prize>,
-    prizeRepository: PrizeRepository,
-    prizeAuthorizationService: PrizeAuthorizationService
-  ) {
+  async deletePrize({
+    prizeOptions,
+    prizeRepository,
+    prizeAuthorizationService
+  }: PrizeRequestContext) {
     const prize = await prizeRepository.findOneOrFail(prizeOptions);
     await prizeAuthorizationService.canDelete(prize);
     const result = await prizeRepository.delete(prize);

--- a/packages/api/src/models/prize/PrizeDetailController.ts
+++ b/packages/api/src/models/prize/PrizeDetailController.ts
@@ -10,6 +10,7 @@ import { PrizeController, PrizeRequestContext } from "./PrizeController";
 export class PrizeDetailController extends PrizeController {
   /**
    * GET a specific prize.
+   * @inject
    */
   @Route({
     route: PrizeController.detailRoute,
@@ -28,6 +29,7 @@ export class PrizeDetailController extends PrizeController {
 
   /**
    * PATCH a prize with the request body.
+   * @inject
    */
   @Route({
     route: PrizeController.detailRoute,
@@ -50,6 +52,7 @@ export class PrizeDetailController extends PrizeController {
 
   /**
    * DELETE a prize.
+   * @inject
    */
   @Route({
     route: PrizeController.detailRoute,

--- a/packages/api/src/models/prize/PrizeListController.ts
+++ b/packages/api/src/models/prize/PrizeListController.ts
@@ -1,12 +1,8 @@
-import { FindManyOptions } from "typeorm";
 import { HttpMethod } from "../../HttpMethod";
 import { Controller } from "../../reflection/Controller";
 import { Route } from "../../reflection/Route";
-import { Game } from "../Game";
 import { Prize } from "../Prize";
-import { PrizeAuthorizationService } from "./PrizeAuthorizationService";
-import { PrizeController } from "./PrizeController";
-import { PrizeRepository } from "./PrizeRepository";
+import { PrizeController, PrizeRequestContext } from "./PrizeController";
 
 @Controller()
 export class PrizeListController extends PrizeController {
@@ -18,12 +14,12 @@ export class PrizeListController extends PrizeController {
     method: HttpMethod.POST,
     roles: ["admin"]
   })
-  async createPrize(
-    requestBody: any,
-    prizeRepository: PrizeRepository,
-    prizeAuthorizationService: PrizeAuthorizationService,
-    game: Game
-  ): Promise<Prize> {
+  async createPrize({
+    requestBody,
+    prizeRepository,
+    prizeAuthorizationService,
+    game
+  }: PrizeRequestContext): Promise<Prize> {
     const body = this.parseBodyForCreate(requestBody);
     const prize = prizeRepository.create();
     prizeRepository.merge(prize, body);
@@ -41,10 +37,7 @@ export class PrizeListController extends PrizeController {
     method: HttpMethod.GET,
     roles: ["public"]
   })
-  async getPrizes(
-    prizeOptions: FindManyOptions<Prize>,
-    prizeRepository: PrizeRepository
-  ) {
+  async getPrizes({ prizeOptions, prizeRepository }: PrizeRequestContext) {
     return await prizeRepository.find(prizeOptions);
   }
 }

--- a/packages/api/src/models/prize/PrizeListController.ts
+++ b/packages/api/src/models/prize/PrizeListController.ts
@@ -8,6 +8,7 @@ import { PrizeController, PrizeRequestContext } from "./PrizeController";
 export class PrizeListController extends PrizeController {
   /**
    * Create a new prize.
+   * @inject
    */
   @Route({
     route: PrizeController.listRoute,
@@ -31,6 +32,7 @@ export class PrizeListController extends PrizeController {
 
   /**
    * Fetch all prizes for a game.
+   * @inject
    */
   @Route({
     route: PrizeController.listRoute,

--- a/packages/api/src/models/prize/PrizeRepository.ts
+++ b/packages/api/src/models/prize/PrizeRepository.ts
@@ -41,3 +41,9 @@ export class PrizeRepository extends Repository<Prize> {
       .getMany();
   }
 }
+
+declare global {
+  interface ApplicationContext {
+    prizeRepository: PrizeRepository;
+  }
+}

--- a/packages/api/src/models/prize/PrizeRepository.ts
+++ b/packages/api/src/models/prize/PrizeRepository.ts
@@ -1,6 +1,6 @@
 import { EntityRepository, MoreThan, Repository } from "typeorm";
 import { Game } from "../Game";
-import { Prize } from "../Prize";
+import { Prize, prizeAdminFields } from "../Prize";
 
 @EntityRepository(Prize)
 export class PrizeRepository extends Repository<Prize> {

--- a/packages/api/src/models/prize/PrizeRepository.ts
+++ b/packages/api/src/models/prize/PrizeRepository.ts
@@ -35,15 +35,16 @@ export class PrizeRepository extends Repository<Prize> {
    * Fetch all in stock prizes, and acquire a pessimistic lock.
    */
   async getInStockPrizesForUpdate(game: Game | number): Promise<Prize[]> {
-    return await this.createQueryBuilder()
+    return this.createQueryBuilder("prize")
       .setLock("pessimistic_write")
+      .addSelect(prizeAdminFields.map(f => `prize.${f}`))
       .where(PrizeRepository.inStock(game).where)
       .getMany();
   }
 }
 
 declare global {
-  interface ApplicationContext {
+  interface ApplicationContextMembers {
     prizeRepository: PrizeRepository;
   }
 }

--- a/packages/api/src/models/role/RoleController.ts
+++ b/packages/api/src/models/role/RoleController.ts
@@ -1,5 +1,5 @@
-import { Connection } from "typeorm";
 import { RoleLiteral } from "../../auth/RoleLiteral";
+import { ApplicationContext } from "../../config/context/ApplicationContext";
 import {
   IFallbackHandlerMap,
   RestRepositoryController
@@ -11,7 +11,8 @@ import { Role } from "../Role";
 @Controller()
 export class RoleController extends RestRepositoryController<Role> {
   protected defaultRoles: RoleLiteral[] = ["public"];
-  constructor(orm: Connection) {
+  /** @inject */
+  constructor({ orm }: ApplicationContext) {
     super(orm, Role);
   }
 

--- a/packages/api/src/models/user/UserController.ts
+++ b/packages/api/src/models/user/UserController.ts
@@ -45,6 +45,7 @@ export class UserController extends RestRepositoryController<User> {
 
   /**
    * Remove a role from a user.
+   * @inject
    */
   @Route({
     route: "/users/{userId}/roles/{roleId}",

--- a/packages/api/src/reflection/Route.ts
+++ b/packages/api/src/reflection/Route.ts
@@ -1,4 +1,5 @@
 import { RoleLiteral } from "../auth/RoleLiteral";
+import { RequestContext } from "../config/context/RequestContext";
 import { HttpMethod } from "../HttpMethod";
 import { IRoutableMethod } from "./IRoutableMethod";
 import { IRouterClass } from "./IRouterClass";
@@ -27,7 +28,7 @@ export function Route(
   return function(
     target: any,
     propertyKey: string,
-    descriptor: PropertyDescriptor
+    descriptor: TypedPropertyDescriptor<(context: RequestContext) => any>
   ) {
     const value = descriptor.value as IRoutableMethod;
     let requestedRoute: string;

--- a/packages/api/src/web/RouteRegistry.ts
+++ b/packages/api/src/web/RouteRegistry.ts
@@ -144,3 +144,10 @@ type IRouteHandler = {
 interface IRouteMap {
   [route: string]: IRouteHandler | undefined;
 }
+
+declare global {
+  interface ApplicationContext {
+    /** The registry of all routes that this application covers */
+    routeRegistry: RouteRegistry;
+  }
+}

--- a/packages/api/src/web/RouteRegistry.ts
+++ b/packages/api/src/web/RouteRegistry.ts
@@ -1,5 +1,6 @@
 import { Resolver } from "awilix";
 import { RoleLiteral } from "../auth/RoleLiteral";
+import { ApplicationContext } from "../config/context/ApplicationContext";
 import { RouteTransformationService } from "../config/RouteTransformationService";
 import { HttpMethod } from "../HttpMethod";
 import { logger } from "../logging";
@@ -14,7 +15,8 @@ export class RouteRegistry {
   /** Data structure mapping route -> method -> resolver */
   private map: IRouteMap;
   private transformationService: RouteTransformationService;
-  constructor(routeTransformationService: RouteTransformationService) {
+  /** @inject */
+  constructor({ routeTransformationService }: ApplicationContext) {
     this.map = {};
     this.transformationService = routeTransformationService;
   }

--- a/packages/api/src/web/RouteRegistry.ts
+++ b/packages/api/src/web/RouteRegistry.ts
@@ -146,7 +146,7 @@ interface IRouteMap {
 }
 
 declare global {
-  interface ApplicationContext {
+  interface ApplicationContextMembers {
     /** The registry of all routes that this application covers */
     routeRegistry: RouteRegistry;
   }

--- a/packages/constants/lib/constants.d.ts
+++ b/packages/constants/lib/constants.d.ts
@@ -21,4 +21,15 @@ declare module "@clovercoin/constants" {
   export type ArgumentTypes<T> = T extends (...args: infer U) => infer R
   ? U
   : never;
+
+  /**
+   * "Spread" type U onto type T. Example:
+   * interface Base {
+   *   a: string;
+   *   b: number;
+   * }
+   * type PartiallyExtendsBase = Assign<Base, {a: number, c: boolean}>;
+   * // { a: number; b: number; c: boolean }
+   */
+  export type Assign<T, U> = Omit<T, keyof U> & U;
 }

--- a/packages/web-client/src/services/auth/AuthenticationService.ts
+++ b/packages/web-client/src/services/auth/AuthenticationService.ts
@@ -98,3 +98,9 @@ export class AuthenticationService {
     return role.name === ROLES.admin;
   }
 }
+
+declare global {
+  interface ApplicationContext {
+    authenticationService: AuthenticationService;
+  }
+}


### PR DESCRIPTION
This PR:

- Removes classic-mode injection
- Adds complete typing for the root container's `cradle` as `ApplicationContext`
- Adds complete typing for request container's `cradle` as  `RequestContext`
- Adds support for enhanced request contexts as `EnhancedRequestContext<T>`
- Refactors all existing injected methods to use destructuring for proxy-based injection
- Stops registration of individual path variables at their own name, refactors all methods relying on that into destructuring off of the `pathVariables` requestContext member
- Adds more strict typing to `@Route` decorator to enforce better type safety
- Add prizeAdminFields to prize model, fix bug when successfully drawing a prize
- Add `@inject` to all DI-managed methods