### PR TITLE
[109] Add Local Accounts

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -15,6 +15,7 @@
   "license": "UNLICENSED",
   "devDependencies": {
     "@types/axios": "^0.14.0",
+    "@types/bcrypt": "^3.0.0",
     "@types/glob": "^5.0.35",
     "@types/jest": "^24.0.14",
     "@types/jsonwebtoken": "^7.2.8",
@@ -48,6 +49,7 @@
     "@clovercoin/constants": "^0.0.0",
     "awilix": "^3.0.9",
     "axios": "^0.18.0",
+    "bcrypt": "^3.0.6",
     "date-fns": "^1.30.1",
     "glob": "^7.1.3",
     "jsonwebtoken": "^8.3.0",

--- a/packages/api/src/auth/AuthenticationService.spec.ts
+++ b/packages/api/src/auth/AuthenticationService.spec.ts
@@ -1,6 +1,6 @@
 import { Repository } from "typeorm";
 import { ApplicationContext } from "../config/context/ApplicationContext";
-import { Role, User } from "../models";
+import { Role, User, LocalCredentials } from "../models";
 import { createSafeContext, getRejectReason } from "../test/testUtils";
 import { AuthenticationService } from "./AuthenticationService";
 import { DeviantartApiConsumer } from "./deviantart/DeviantartApiConsumer";
@@ -12,6 +12,7 @@ import { JsonWebTokenError, TokenExpiredError } from "jsonwebtoken";
 import { ArgumentTypes } from "@clovercoin/constants";
 import { AuthenticationFailureException } from "./AuthenticationFailureException";
 import { AuthenticationTokenExpiredError } from "./AuthenticationTokenExpiredError";
+import { PasswordHashingService } from "./PasswordHashingService";
 
 describe("service:AuthenticationService", () => {
   afterEach(() => {
@@ -29,6 +30,8 @@ describe("service:AuthenticationService", () => {
       user: User;
       tokenService: jest.Mocked<TokenService>;
       token: string;
+      passwordHashingService: PasswordHashingService;
+      localCredentialsRepository: Repository<LocalCredentials>;
     }
     let mocks: IMocks;
     let authenticationService: AuthenticationService;
@@ -51,9 +54,9 @@ describe("service:AuthenticationService", () => {
           type: "some_type"
         },
         user: {
-          deviantartName: "some_da_username",
+          displayName: "some_da_username",
           iconUrl: "some_icon_url",
-          deviantartUuid: "some_da_uuid",
+          id: 245,
           roles: [mockRoles.user]
         },
         token: "some_jwt",
@@ -71,7 +74,11 @@ describe("service:AuthenticationService", () => {
         deviantartApiConsumer: {
           authenticate: jest.fn(),
           getUser: jest.fn()
-        } as any
+        } as any,
+        passwordHashingService: {
+          hashPassword: jest.fn(),
+          verifyPasswordHash: jest.fn()
+        }
       };
       /* Stubs */
       mocks.deviantartApiConsumer.authenticate.mockResolvedValue(

--- a/packages/api/src/auth/AuthenticationService.ts
+++ b/packages/api/src/auth/AuthenticationService.ts
@@ -95,7 +95,6 @@ export class AuthenticationService {
     );
     let user = daAccount && daAccount.user;
     if (!daAccount) {
-      // TODO: this should be done in a transaction
       // create the new user
       user = await this.userRepository.createFromDeviantartUser(daUser, [
         await defaultRole

--- a/packages/api/src/auth/AuthenticationService.ts
+++ b/packages/api/src/auth/AuthenticationService.ts
@@ -2,30 +2,67 @@ import { ROLES } from "@clovercoin/constants";
 import { TokenExpiredError } from "jsonwebtoken";
 import { Repository } from "typeorm";
 import { ApplicationContext } from "../config/context/ApplicationContext";
-import { Role, User } from "../models";
+import { Role, LocalCredentials } from "../models";
 import { Component } from "../reflection/Component";
 import { AuthenticationFailureException } from "./AuthenticationFailureException";
 import { AuthenticationTokenExpiredError } from "./AuthenticationTokenExpiredError";
 import { DeviantartApiConsumer } from "./deviantart/DeviantartApiConsumer";
 import { IDeviantartUser } from "./deviantart/IDeviantartUser";
 import { TokenService } from "./TokenService";
+import { PasswordHashingService } from "./PasswordHashingService";
+import { DeviantartAccount } from "../models/DeviantartAccount";
+import { UserRepository } from "../models/user/UserRepository";
+import { ITokenPayload } from "./ITokenPayload";
 @Component()
 export class AuthenticationService {
   private client: DeviantartApiConsumer;
   private roleRepository: Repository<Role>;
-  private userRepository: Repository<User>;
+  private userRepository: UserRepository;
   private tokenService: TokenService;
+  private passwordHashingService: PasswordHashingService;
+  private localCredentialsRepository: Repository<LocalCredentials>;
+  private deviantartAccountRepository: Repository<DeviantartAccount>;
   /** @inject */
   constructor({
     deviantartApiConsumer,
     roleRepository,
     userRepository,
-    tokenService
+    tokenService,
+    passwordHashingService,
+    localCredentialsRepository,
+    deviantartAccountRepository
   }: ApplicationContext) {
     this.client = deviantartApiConsumer;
     this.roleRepository = roleRepository;
     this.userRepository = userRepository;
     this.tokenService = tokenService;
+    this.passwordHashingService = passwordHashingService;
+    this.localCredentialsRepository = localCredentialsRepository;
+    this.deviantartAccountRepository = deviantartAccountRepository;
+  }
+
+  /**
+   * Create and save a new user with local credentials. The user will have the
+   * default user role.
+   * @param principal - The principal the user with authenticate with. Also
+   *  set as the display name.
+   * @param password  - The password the user will authenticate with.
+   * @return The new user
+   */
+  async registerUser(principal: string, password: string) {
+    const defaultRolePromise = this.roleRepository.findOneOrFail({
+      name: ROLES.user
+    });
+    const hashPromise = this.passwordHashingService.hashPassword(password);
+    const [defaultRole, passwordHash] = await Promise.all([
+      defaultRolePromise,
+      hashPromise
+    ]);
+    return this.userRepository.createLocalUser({
+      principal,
+      passwordHash,
+      roles: [defaultRole]
+    });
   }
 
   /**
@@ -46,41 +83,49 @@ export class AuthenticationService {
     });
     // fetch the deviantart account info
     const daUser: IDeviantartUser = await this.client.getUser(loginResult);
+
+    const conditions = {
+      deviantartUuid: daUser.userId
+    };
+    const options = { relations: ["user"] };
     // check if they already exist
-    let user: User | undefined = await this.userRepository.findOne(
-      daUser.userId
+    let daAccount = await this.deviantartAccountRepository.findOne(
+      conditions,
+      options
     );
-    if (!user) {
+    let user = daAccount && daAccount.user;
+    if (!daAccount) {
+      // TODO: this should be done in a transaction
       // create the new user
-      user = this.userRepository.create();
-      user.iconUrl = daUser.userIcon;
-      user.deviantartUuid = daUser.userId;
-      user.deviantartName = daUser.username;
-      user.roles = [await defaultRole];
-      user = await this.userRepository.save(user);
+      user = await this.userRepository.createFromDeviantartUser(daUser, [
+        await defaultRole
+      ]);
     } else {
       // update any info that needs it
+      user = daAccount.user;
       const shouldUpdateIconUrl = user.iconUrl !== daUser.userIcon;
-      const shouldUpdateUsername = user.deviantartName !== daUser.username;
+      const shouldUpdateUsername = user.displayName !== daUser.username;
       const shouldUpdate = shouldUpdateUsername || shouldUpdateIconUrl;
       if (shouldUpdate) {
         user.iconUrl = daUser.userIcon;
-        user.deviantartName = daUser.username;
+        user.displayName = daUser.username;
         user = await this.userRepository.save(user);
       }
     }
     // create and return an access token
     return this.tokenService.createToken({
       accessToken: loginResult.accessToken,
-      sub: user.deviantartUuid
+      sub: user.id
     });
   }
 
   /**
    * Validate the given token. Returns the parsed token payload. Throws an
    * AuthenticationFailureException in the event of failure.
+   * @param token - The token to validate
+   * @return The token's payload
    */
-  async authenticateToken(token: string) {
+  async authenticateToken(token: string): Promise<ITokenPayload> {
     try {
       return await this.tokenService.readToken(token);
     } catch (e) {
@@ -95,6 +140,75 @@ export class AuthenticationService {
       }
       throw new AuthenticationFailureException(message);
     }
+  }
+
+  /**
+   * Authenticate a user using their local credentials, and create a token
+   * for them.
+   * @throws AuthenticationFailureException if authentication fails
+   * @param principal - The credential's principal
+   * @param password  - The credential's password
+   * @return A bearer token for the user authenticated by the provided principal
+   *  and password.
+   */
+  async authenticateCredentials(
+    principal: string,
+    password: string
+  ): Promise<string> {
+    const { localCredentialsRepository, passwordHashingService } = this;
+    if (
+      !principal ||
+      !password ||
+      typeof principal !== "string" ||
+      typeof password !== "string"
+    ) {
+      throw new AuthenticationFailureException(
+        "Login and password are required to authenticate."
+      );
+    }
+    if (password.length < 2) {
+      throw new AuthenticationFailureException(
+        "Invalid password, password must be greater than 2 characters."
+      );
+    }
+    // construct a dummy password that is different from the supplied password
+    const dummyPassword = password.substr(1);
+    if (dummyPassword.length === password.length) {
+      throw new AuthenticationFailureException();
+    }
+    // hash it so we have a hash to compare with in the event the user is not found
+    const dummyPasswordHash = await passwordHashingService.hashPassword(
+      dummyPassword
+    );
+
+    // fetch the credentials by principal
+    const conditions = { principal };
+    const options = { relations: ["user"] };
+    const credentials = await localCredentialsRepository.findOne(
+      conditions,
+      options
+    );
+
+    // if no credentials are found, use the dummy password hash
+    const storedPasswordHash = credentials
+      ? credentials.password
+      : dummyPasswordHash;
+
+    const passwordsMatch = await passwordHashingService.verifyPasswordHash(
+      password,
+      storedPasswordHash
+    );
+
+    const loginResult = Boolean(passwordsMatch && credentials);
+    if (!loginResult) {
+      throw new AuthenticationFailureException("Invalid credentials");
+    }
+
+    const user = credentials!.user;
+    return this.tokenService.createToken({
+      accessToken: null,
+      sub: user.id
+    });
   }
 }
 

--- a/packages/api/src/auth/PasswordHashingService.spec.ts
+++ b/packages/api/src/auth/PasswordHashingService.spec.ts
@@ -1,0 +1,90 @@
+import { PasswordHashingService } from "./PasswordHashingService";
+import * as bcrypt from "bcrypt";
+
+describe("PasswordHashingService", () => {
+  let svc: PasswordHashingService;
+  beforeEach(() => {
+    svc = new PasswordHashingService();
+  });
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+  describe("hashPassword", () => {
+    it("rejects if the password is empty", () => {
+      return expect(svc.hashPassword("")).rejects.toMatchInlineSnapshot(
+        `[Error: Non-empty password required to hash]`
+      );
+    });
+    it("rejects if the password is over 72 characters", async () => {
+      const password = "f".repeat(73);
+      expect(svc.hashPassword(password)).rejects.toMatchInlineSnapshot(
+        `[Error: Maximum password length exceeded, must not be greater than: 72]`
+      );
+
+      // justification for this test:
+      const hash = await bcrypt.hash(password, 10);
+      const otherPassword = password + "f";
+      // passwords don't match
+      expect(otherPassword).not.toEqual(password);
+      // but otherPassword still satisfies our hash!
+      await expect(bcrypt.compare(otherPassword, hash)).resolves.toBe(true);
+    });
+    it("returns the bcrypt hash with 10 salt rounds", async () => {
+      const mockResult = "ting tang wallawallabingbang";
+      jest.spyOn(bcrypt, "hash").mockResolvedValue(mockResult);
+      const password = "f".repeat(72);
+      const result = await svc.hashPassword("f".repeat(72));
+      expect(result).toBe(mockResult);
+      expect(bcrypt.hash).toHaveBeenCalledWith(password, 10);
+    });
+  });
+  describe("verifyPasswordHash", () => {
+    it("throws if password or hash are empty", async () => {
+      jest.spyOn(bcrypt, "compare").mockResolvedValue(true);
+      const password = "somePassword";
+      const hash = "0xSomeHash";
+      await expect(
+        svc.verifyPasswordHash("", hash)
+      ).rejects.toMatchInlineSnapshot(
+        `[Error: Password and existing hash both required to verify credentials.]`
+      );
+      await expect(
+        svc.verifyPasswordHash(password, "")
+      ).rejects.toMatchInlineSnapshot(
+        `[Error: Password and existing hash both required to verify credentials.]`
+      );
+    });
+    it("returns the result of bcrypt compare", async () => {
+      const mockResult = {} as any;
+      jest.spyOn(bcrypt, "compare").mockResolvedValue(mockResult);
+      const password = "somePassword";
+      const hash = "0xSomeHash";
+      const result = await svc.verifyPasswordHash(password, hash);
+      expect(result).toBe(mockResult);
+      expect(bcrypt.compare).toHaveBeenCalledWith(password, hash);
+    });
+  });
+  describe("integration", () => {
+    describe.each([
+      "somePassword",
+      "$123.45aF",
+      "ûteXx",
+      "aA01189998819991187253",
+      "aA".repeat(36)
+    ])("valid password: %p", (password: string) => {
+      it("matches: " + password, async () => {
+        const hash = await svc.hashPassword(password);
+        const matches = await svc.verifyPasswordHash(password, hash);
+        expect(matches).toBe(true);
+      });
+      it("does not match: " + password.toLowerCase(), async () => {
+        const hash = await svc.hashPassword(password);
+        const matches = await svc.verifyPasswordHash(
+          password.toLowerCase(),
+          hash
+        );
+        expect(matches).toBe(false);
+      });
+    });
+  });
+});

--- a/packages/api/src/auth/PasswordHashingService.ts
+++ b/packages/api/src/auth/PasswordHashingService.ts
@@ -14,11 +14,11 @@ export class PasswordHashingService {
   async hashPassword(password: string): Promise<string> {
     if (!password) {
       const msg = "Non-empty password required to hash";
-      return Promise.reject(new Error(msg));
+      throw new Error(msg);
     }
     if (password.length > BCRYPT_MAX_INPUT_LENGTH) {
       const msg = `Maximum password length exceeded, must not be greater than: ${BCRYPT_MAX_INPUT_LENGTH}`;
-      return Promise.reject(new Error(msg));
+      throw new Error(msg);
     }
     return hash(password, SALT_ROUNDS);
   }
@@ -36,7 +36,7 @@ export class PasswordHashingService {
     if (!password || !passwordHash) {
       const msg =
         "Password and existing hash both required to verify credentials.";
-      return Promise.reject(new Error(msg));
+      throw new Error(msg);
     }
     return compare(password, passwordHash);
   }

--- a/packages/api/src/auth/PasswordHashingService.ts
+++ b/packages/api/src/auth/PasswordHashingService.ts
@@ -1,0 +1,49 @@
+import { Component } from "../reflection/Component";
+import { hash, compare } from "bcrypt";
+
+const BCRYPT_MAX_INPUT_LENGTH = 72;
+const SALT_ROUNDS = 10;
+
+@Component()
+export class PasswordHashingService {
+  /**
+   * Hash a password for storage in the database.
+   * @param password - The password to hash
+   * @return The hashed password with its salt included.
+   */
+  async hashPassword(password: string): Promise<string> {
+    if (!password) {
+      const msg = "Non-empty password required to hash";
+      return Promise.reject(new Error(msg));
+    }
+    if (password.length > BCRYPT_MAX_INPUT_LENGTH) {
+      const msg = `Maximum password length exceeded, must not be greater than: ${BCRYPT_MAX_INPUT_LENGTH}`;
+      return Promise.reject(new Error(msg));
+    }
+    return hash(password, SALT_ROUNDS);
+  }
+
+  /**
+   * Verify a password against a hash + salt.
+   * @param password - The incoming password to verify
+   * @param passwordHash - The password hash to verify against
+   * @return True if the password matches
+   */
+  async verifyPasswordHash(
+    password: string,
+    passwordHash: string
+  ): Promise<boolean> {
+    if (!password || !passwordHash) {
+      const msg =
+        "Password and existing hash both required to verify credentials.";
+      return Promise.reject(new Error(msg));
+    }
+    return compare(password, passwordHash);
+  }
+}
+
+declare global {
+  interface ApplicationContextMembers {
+    passwordHashingService: PasswordHashingService;
+  }
+}

--- a/packages/api/src/auth/TokenService.spec.ts
+++ b/packages/api/src/auth/TokenService.spec.ts
@@ -13,7 +13,7 @@ describe("service:TokenService", () => {
       envService: jest.Mocked<EnvService>;
       tokenConfig: ITokenConfiguration;
       payload: {
-        sub: string;
+        sub: number;
         accessToken: string;
       };
     }
@@ -29,7 +29,7 @@ describe("service:TokenService", () => {
         secret: "test_secret"
       };
       mocks.payload = {
-        sub: "userid",
+        sub: 123,
         accessToken: "access_token"
       };
       mocks = createSafeContext(mocks);

--- a/packages/api/src/auth/TokenService.ts
+++ b/packages/api/src/auth/TokenService.ts
@@ -56,9 +56,9 @@ export class TokenService {
  */
 interface ITokenData {
   /** Subject, should be the user's unique identifier. */
-  sub: string;
+  sub: number;
   /** Deviantart api access token. */
-  accessToken: string;
+  accessToken: string | null;
 }
 
 declare global {

--- a/packages/api/src/db/CustomRepository.ts
+++ b/packages/api/src/db/CustomRepository.ts
@@ -1,0 +1,11 @@
+import { Repository } from "typeorm";
+import { AnyContext } from "../config/context/ApplicationContext";
+
+export abstract class CustomRepository<ModelType> extends Repository<
+  ModelType
+> {
+  /**
+   * Method invoked to update the application context for the repository.
+   */
+  abstract setContext(ctx: AnyContext): void;
+}

--- a/packages/api/src/models/DeviantartAccount.ts
+++ b/packages/api/src/models/DeviantartAccount.ts
@@ -1,0 +1,32 @@
+import {
+  Entity,
+  OneToOne,
+  RelationId,
+  PrimaryColumn,
+  JoinColumn
+} from "typeorm";
+import { User } from "./User";
+
+@Entity()
+export class DeviantartAccount {
+  /**
+   * The user who owns this DA association
+   */
+  @OneToOne(type => User, {
+    nullable: false
+  })
+  @JoinColumn()
+  user!: User;
+
+  /**
+   * The ID of the user for this account
+   */
+  @RelationId((deviantartAccount: DeviantartAccount) => deviantartAccount.user)
+  userId!: number;
+
+  /**
+   * The deviantart UUID for this account
+   */
+  @PrimaryColumn()
+  deviantartUuid!: string;
+}

--- a/packages/api/src/models/DrawEvent/DrawController.spec.ts
+++ b/packages/api/src/models/DrawEvent/DrawController.spec.ts
@@ -238,13 +238,13 @@ describe("DrawController", () => {
       container.register("user", asValue(mockUsers.user));
       container.register(
         "pathVariables",
-        asValue({ userId: mockUsers.user.deviantartUuid })
+        asValue({ userId: mockUsers.user.id })
       );
     });
     it("fetches prizes for the current user", async () => {
       await container.build(bind(controller.getDraws, controller));
       expect(mocks.drawEventRepository.find).toHaveBeenCalledWith({
-        where: { user: mockUsers.user.deviantartUuid }
+        where: { user: mockUsers.user.id }
       });
     });
     it("bubbles errors from drawEventAuthorizationService.canReadMultiple", async () => {

--- a/packages/api/src/models/DrawEvent/DrawController.ts
+++ b/packages/api/src/models/DrawEvent/DrawController.ts
@@ -72,8 +72,6 @@ export class DrawController {
       await drawEventAuthorizationService.canCreate(loseDrawEvent);
       return await drawEventRepository.save(loseDrawEvent);
     }
-    let drawEvent: DrawEvent;
-    // run all of this in a transaction so it's all nice and atomic
     return await transactionService.runTransaction(
       /** @inject */
       async ({ prizeRepository, drawEventRepository }: RequestContext) => {
@@ -90,8 +88,7 @@ export class DrawController {
         const selectedPrize = selectRandomItemFromPool(prizes, prize => {
           return Math.floor(prize.weight * 100) * prize.currentStock;
         });
-
-        drawEvent = drawEventRepository.create();
+        let drawEvent = drawEventRepository.create();
         drawEvent.user = user;
         drawEvent.prize = selectedPrize;
         drawEvent.game = game;

--- a/packages/api/src/models/DrawEvent/DrawEventAuthorizationService.spec.ts
+++ b/packages/api/src/models/DrawEvent/DrawEventAuthorizationService.spec.ts
@@ -49,7 +49,7 @@ describe("DrawEventAuthorizationService", () => {
       // const mockUser = mockUsers.user;
       const mockDrawEvent = new DrawEvent();
       mockDrawEvent.user = mockUsers.user;
-      mockDrawEvent.user.deviantartUuid = "a-different-uuid";
+      mockDrawEvent.user.id = mockDrawEvent.user.id + 100;
       await expect(
         service.canCreate(
           // mockUser,
@@ -127,7 +127,7 @@ describe("DrawEventAuthorizationService", () => {
       async roleName => {
         const mockDrawEvent = new DrawEvent();
         mockDrawEvent.user = mockUsers.user;
-        mockDrawEvent.user.deviantartUuid = "some-other-uuid";
+        mockDrawEvent.user.id = mockDrawEvent.user.id + 100;
         const mockUser = mockUsers[roleName];
         await expect(
           service.canRead(mockUser, mockDrawEvent)
@@ -166,7 +166,7 @@ describe("DrawEventAuthorizationService", () => {
       "allows %p to read their own",
       async roleName => {
         const mockUser = mockUsers[roleName];
-        const filter = { where: { user: mockUser.deviantartUuid } };
+        const filter = { where: { user: mockUser.id } };
         await expect(service.canReadMultiple(filter, mockUser)).resolves.toBe(
           true
         );
@@ -177,7 +177,7 @@ describe("DrawEventAuthorizationService", () => {
       "does not allow %p to read multiple of others",
       async roleName => {
         const mockUser = mockUsers[roleName];
-        const filter = { where: { user: mockUser.deviantartUuid + "1" } };
+        const filter = { where: { user: mockUser.id + 1 } };
         await expect(
           service.canReadMultiple(filter, mockUser)
         ).rejects.toBeInstanceOf(PermissionDeniedError);

--- a/packages/api/src/models/DrawEvent/DrawEventAuthorizationService.ts
+++ b/packages/api/src/models/DrawEvent/DrawEventAuthorizationService.ts
@@ -43,10 +43,7 @@ export class DrawEventAuthorizationService {
     }
     user = user!;
     // people can only make draws for themselves
-    if (
-      !createEvent.user ||
-      createEvent.user.deviantartUuid !== user.deviantartUuid
-    ) {
+    if (!createEvent.user || createEvent.user.id !== user.id) {
       throw new PermissionDeniedError();
     }
     // admins don't have to wait
@@ -101,13 +98,13 @@ export class DrawEventAuthorizationService {
       throw new PermissionDeniedError();
     }
     const whereUser = findOptions.where.user;
-    let whereUserId: string;
-    if (typeof whereUser === "string") {
+    let whereUserId: number;
+    if (typeof whereUser === "number") {
       whereUserId = whereUser;
     } else {
       whereUserId = whereUser.deviantartUuid;
     }
-    if (whereUserId !== user.deviantartUuid) {
+    if (whereUserId !== user.id) {
       throw new PermissionDeniedError();
     }
     return true;
@@ -123,7 +120,7 @@ export class DrawEventAuthorizationService {
       throw new PermissionDeniedError();
     }
     const isAdmin = hasRole(user, "admin");
-    const isOwnEvent = drawEvent.user.deviantartUuid === user.deviantartUuid;
+    const isOwnEvent = drawEvent.user.id === user.id;
     const canRead = isAdmin || isOwnEvent;
     if (!canRead) {
       throw new PermissionDeniedError();

--- a/packages/api/src/models/LocalCredentials.ts
+++ b/packages/api/src/models/LocalCredentials.ts
@@ -1,0 +1,45 @@
+import {
+  Entity,
+  Column,
+  OneToOne,
+  RelationId,
+  JoinColumn,
+  PrimaryGeneratedColumn
+} from "typeorm";
+import { User } from "./User";
+
+@Entity()
+/**
+ * Login credentials for users that use local authentication.
+ */
+export class LocalCredentials {
+  /**
+   * The user that is authenticated by these credentials.
+   */
+  @OneToOne(type => User, {
+    nullable: false
+  })
+  @JoinColumn()
+  user!: User;
+
+  @RelationId((localCredentials: LocalCredentials) => localCredentials.user)
+  userId!: number;
+
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  /**
+   * The login (username/email/w/e for this user)
+   */
+  @Column({
+    unique: true,
+    length: 255
+  })
+  principal!: string;
+
+  /**
+   * The hashed password for this user.
+   */
+  @Column({ nullable: false })
+  password!: string;
+}

--- a/packages/api/src/models/User.ts
+++ b/packages/api/src/models/User.ts
@@ -1,15 +1,28 @@
-import { Column, Entity, JoinTable, ManyToMany, PrimaryColumn } from "typeorm";
+import {
+  Column,
+  Entity,
+  JoinTable,
+  ManyToMany,
+  PrimaryGeneratedColumn
+} from "typeorm";
 import { Role } from "./Role";
-@Entity({
-  name: "halloweenUsers"
-})
+@Entity()
 export class User {
-  @PrimaryColumn()
-  deviantartUuid!: string;
-  @Column()
-  deviantartName!: string;
-  @Column()
-  iconUrl!: string;
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column({
+    nullable: false
+  })
+  displayName!: string;
+
+  @Column({
+    default: null,
+    nullable: true,
+    type: "varchar"
+  })
+  iconUrl: string | null = null;
+
   @ManyToMany(type => Role, {
     eager: true
   })

--- a/packages/api/src/models/deviantartAccount/DeviantartAccountRepository.ts
+++ b/packages/api/src/models/deviantartAccount/DeviantartAccountRepository.ts
@@ -1,0 +1,33 @@
+import { CustomRepository } from "../../db/CustomRepository";
+import { DeviantartAccount } from "../DeviantartAccount";
+import { IDeviantartUser } from "../../auth/deviantart/IDeviantartUser";
+import { User } from "../User";
+import { EntityRepository } from "typeorm";
+
+@EntityRepository(DeviantartAccount)
+export class DeviantartAccountRepository extends CustomRepository<
+  DeviantartAccount
+> {
+  setContext() {
+    // noop
+  }
+
+  /**
+   * Create and save a new DeviantartAccount from a DA user. Does not save the DA account
+   * to the database or set the `user`.
+   * @param daUser - The Deviantart user to create an auth account for
+   * @return The new DeviantartAccount
+   */
+  associateDeviantartUser(user: User, daUser: IDeviantartUser) {
+    const daAccount = this.create();
+    daAccount.deviantartUuid = daUser.userId;
+    daAccount.user = user;
+    return this.save(daAccount);
+  }
+}
+
+declare global {
+  interface ApplicationContextMembers {
+    deviantartAccountRepository: DeviantartAccountRepository;
+  }
+}

--- a/packages/api/src/models/index.ts
+++ b/packages/api/src/models/index.ts
@@ -9,6 +9,9 @@ export { User } from "./User";
 import { Repository } from "typeorm";
 import { Game } from "./Game";
 export { Game } from "./Game";
+import { LocalCredentials } from "./LocalCredentials";
+import { DeviantartAccount } from "./DeviantartAccount";
+export { LocalCredentials } from "./LocalCredentials";
 /**
  * Interface representing a model constructor function.
  */
@@ -16,7 +19,15 @@ export interface IModelClass<T = any> {
   createInitialEntities?: (...args: any[]) => Promise<any>;
   new (...args: any[]): T;
 }
-export const MODELS: IModelClass[] = [User, Prize, Role, DrawEvent, Game];
+export const MODELS: IModelClass[] = [
+  User,
+  Prize,
+  Role,
+  DrawEvent,
+  Game,
+  LocalCredentials,
+  DeviantartAccount
+];
 
 declare global {
   interface ApplicationContextMembers {
@@ -24,7 +35,6 @@ declare global {
     // if a custom repository is created for any model in this list,
     // remove it from here and declare its more specific type in the
     // implementation file
-    userRepository: Repository<User>;
     roleRepository: Repository<Role>;
     gameRepository: Repository<Game>;
   }

--- a/packages/api/src/models/localCredentials/LocalCredentialsRepository.ts
+++ b/packages/api/src/models/localCredentials/LocalCredentialsRepository.ts
@@ -1,0 +1,23 @@
+import { EntityRepository, Repository } from "typeorm";
+import { LocalCredentials } from "../LocalCredentials";
+import { User } from "../User";
+
+@EntityRepository(LocalCredentials)
+export class LocalCredentialsRepository extends Repository<LocalCredentials> {
+  async associateCredentialsWithUser(
+    user: User,
+    credentials: Pick<LocalCredentials, "principal" | "password">
+  ) {
+    const localCredentials = this.create();
+    localCredentials.principal = credentials.principal;
+    localCredentials.password = credentials.password;
+    localCredentials.user = user;
+    return this.save(localCredentials);
+  }
+}
+
+declare global {
+  interface ApplicationContextMembers {
+    localCredentialsRepository: LocalCredentialsRepository;
+  }
+}

--- a/packages/api/src/models/user/UserRepository.ts
+++ b/packages/api/src/models/user/UserRepository.ts
@@ -1,0 +1,90 @@
+import { EntityRepository } from "typeorm";
+import { User } from "../User";
+import { IDeviantartUser } from "../../auth/deviantart/IDeviantartUser";
+import { CustomRepository } from "../../db/CustomRepository";
+import { ApplicationContext } from "../../config/context/ApplicationContext";
+import { Role } from "../Role";
+
+@EntityRepository(User)
+export class UserRepository extends CustomRepository<User> {
+  private transactionService!: ApplicationContext["transactionService"];
+
+  setContext({ transactionService }: ApplicationContext) {
+    this.transactionService = transactionService;
+  }
+
+  /**
+   * Create and save a new user from a deviantart user
+   * @param daUser - The deviantArt user profile to create a user for.
+   * @param roles - The roles to give this user
+   * @return The newly created user
+   */
+  async createFromDeviantartUser(
+    daUser: IDeviantartUser,
+    roles: Role[]
+  ): Promise<User> {
+    return this.transactionService.runTransaction(
+      async ({ userRepository, deviantartAccountRepository }) => {
+        let user = userRepository.create();
+        user.iconUrl = daUser.userIcon;
+        user.displayName = daUser.username;
+        user.roles = [...roles];
+        user = await userRepository.save(user);
+        await deviantartAccountRepository.associateDeviantartUser(user, daUser);
+        return user;
+      }
+    );
+  }
+
+  /**
+   * Create a user with local credentials.
+   * @param options - The options to create the user with.
+   * @see LocalUserCreateOptions
+   * @return The new user
+   */
+  createLocalUser({
+    principal,
+    passwordHash,
+    roles,
+    iconUrl = null
+  }: LocalUserCreateOptions): Promise<User> {
+    return this.transactionService.runTransaction(
+      async ({
+        localCredentialsRepository,
+        userRepository
+      }: ApplicationContext) => {
+        let user = userRepository.create();
+        user.iconUrl = iconUrl;
+        user.displayName = principal;
+        user.roles = [...roles];
+        user = await userRepository.save(user);
+
+        await localCredentialsRepository.associateCredentialsWithUser(user, {
+          principal,
+          password: passwordHash
+        });
+        return user;
+      }
+    );
+  }
+}
+
+/**
+ * Options for creating a user with local credentials
+ */
+export interface LocalUserCreateOptions {
+  /** The principal that the user will authenticate with */
+  principal: string;
+  /** The (hashed) password the user will authenticate with */
+  passwordHash: string;
+  /** The roles for the user */
+  roles: Role[];
+  /** The icon URL for the user, defaults to null */
+  iconUrl?: string | null;
+}
+
+declare global {
+  interface ApplicationContextMembers {
+    userRepository: UserRepository;
+  }
+}

--- a/packages/api/src/models/user/mocks/mockUsers.ts
+++ b/packages/api/src/models/user/mocks/mockUsers.ts
@@ -5,8 +5,8 @@ import { RequestUser } from "../../../middlewares/AuthorizationMiddlewareFactory
 
 const admin = () => {
   const adminUser = new User();
-  adminUser.deviantartName = "Provinite";
-  adminUser.deviantartUuid = "0-0-0-0";
+  adminUser.displayName = "Provinite";
+  adminUser.id = 1;
   adminUser.iconUrl = "http://www.example.com/iconurl.gif";
   adminUser.roles = [mockRoles.admin, mockRoles.user];
   return adminUser;
@@ -14,8 +14,8 @@ const admin = () => {
 
 const user = () => {
   const userUser = new User();
-  userUser.deviantartName = "PillowingFan";
-  userUser.deviantartUuid = "1-1-1-1";
+  userUser.displayName = "PillowingFan";
+  userUser.id = 2;
   userUser.iconUrl = "http://www.example.com/iconurl.ping";
   userUser.roles = [mockRoles.user];
   return userUser;
@@ -23,8 +23,8 @@ const user = () => {
 
 const moderator = () => {
   const moderatorUser = new User();
-  moderatorUser.deviantartName = "TheActualBest";
-  moderatorUser.deviantartUuid = "2-2-2-2";
+  moderatorUser.displayName = "TheActualBest";
+  moderatorUser.id = 3;
   moderatorUser.iconUrl = "http://www.example.com/iconurl.jpg";
   moderatorUser.roles = [mockRoles.moderator, mockRoles.user];
   return moderatorUser;

--- a/packages/api/tslint.json
+++ b/packages/api/tslint.json
@@ -1,5 +1,9 @@
 {
-  "extends": ["tslint:recommended", "tslint-config-prettier", "tslint-plugin-prettier"],
+  "extends": [
+    "tslint:recommended",
+    "tslint-config-prettier",
+    "tslint-plugin-prettier"
+  ],
   "rules": {
     "prettier": true,
     "member-access": [true, "no-public"],
@@ -12,6 +16,7 @@
     "interface-name": false,
     "no-shadowed-variable": false,
     "member-ordering": false,
-    "no-floating-promises": true
+    "no-floating-promises": true,
+    "no-console": true
   }
 }

--- a/packages/web-client/src/components/admin/AdminPage.tsx
+++ b/packages/web-client/src/components/admin/AdminPage.tsx
@@ -347,9 +347,7 @@ export class AdminPage extends React.Component<
     this.setState(prevState => ({
       users: {
         ...prevState.users,
-        list: prevState.users.list.map(u =>
-          u.deviantartUuid === result.deviantartUuid ? result : u
-        )
+        list: prevState.users.list.map(u => (u.id === result.id ? result : u))
       }
     }));
   };
@@ -366,9 +364,7 @@ export class AdminPage extends React.Component<
     this.setState(prevState => ({
       users: {
         ...prevState.users,
-        list: prevState.users.list.map(u =>
-          u.deviantartUuid === result.deviantartUuid ? result : u
-        )
+        list: prevState.users.list.map(u => (u.id === result.id ? result : u))
       }
     }));
   };

--- a/packages/web-client/src/components/admin/AdminUsersTab.tsx
+++ b/packages/web-client/src/components/admin/AdminUsersTab.tsx
@@ -141,13 +141,13 @@ export class AdminUsersTab extends React.Component<
           </TableHead>
           <TableBody>
             {this.props.users.map(user => (
-              <TableRow key={user.deviantartUuid}>
+              <TableRow key={user.id}>
                 <TableCell>
                   <img
-                    src={user.iconUrl}
+                    src={user.iconUrl!}
                     style={{ width: "20px", height: "20px" }}
                   />
-                  {user.deviantartName}
+                  {user.displayName}
                 </TableCell>
                 <TableCell>
                   {/* TODO: Get this stuff going. We want to be able to toggle perms on and off. */}
@@ -171,7 +171,7 @@ export class AdminUsersTab extends React.Component<
                     onChange={this.handleToggle(user, this.context.roles.user)}
                   />
                 </TableCell>
-                <TableCell>{user.deviantartUuid}</TableCell>
+                <TableCell>{user.id}</TableCell>
               </TableRow>
             ))}
           </TableBody>
@@ -186,7 +186,7 @@ export class AdminUsersTab extends React.Component<
           <DialogTitle>
             Make{" "}
             {this.state.userToPromote
-              ? this.state.userToPromote.deviantartName
+              ? this.state.userToPromote.displayName
               : "[no user]"}{" "}
             an administrator?
           </DialogTitle>

--- a/packages/web-client/src/models/IUser.ts
+++ b/packages/web-client/src/models/IUser.ts
@@ -1,8 +1,8 @@
 import { IRole } from "./IRole";
 
 export interface IUser {
-  deviantartUuid: string;
-  deviantartName: string;
-  iconUrl: string;
+  id: number;
+  iconUrl: string | null;
+  displayName: string;
   roles: IRole[];
 }

--- a/packages/web-client/src/services/UserService.ts
+++ b/packages/web-client/src/services/UserService.ts
@@ -54,5 +54,5 @@ export class UserService {
  * Get the detail-route for a user.
  */
 function getDetailRoute(user: IUser) {
-  return `${baseRoute}/${user.deviantartUuid}`;
+  return `${baseRoute}/${user.id}`;
 }

--- a/packages/web-client/src/services/auth/AuthenticationService.ts
+++ b/packages/web-client/src/services/auth/AuthenticationService.ts
@@ -55,11 +55,11 @@ export class AuthenticationService {
       throw new AuthenticationError("Session expired.");
     }
     const { data } = userResponse;
-    if (!data.deviantartName || !data.deviantartUuid || !data.iconUrl) {
+    if (!data.displayName || !data.id || !data.iconUrl) {
       throw new Error("Unexpected response to identity query.");
     }
     const {
-      deviantartName: username,
+      displayName: username,
       deviantartUuid: uuid,
       iconUrl
     } = userResponse.data;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1630,6 +1630,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/bcrypt@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/bcrypt/-/bcrypt-3.0.0.tgz#851489a9065a067cb7f3c9cbe4ce9bed8bba0876"
+  integrity sha512-nohgNyv+1ViVcubKBh0+XiNJ3dO8nYu///9aJ4cgSqv70gBL+94SNy/iC2NLzKPT2Zt/QavrOkBVbZRLZmw6NQ==
+
 "@types/bluebird@*":
   version "3.5.25"
   resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.25.tgz#59188b871208092e37767e4b3d80c3b3eaae43bd"
@@ -2730,6 +2735,14 @@ bcrypt-pbkdf@^1.0.0:
   integrity sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
   dependencies:
     tweetnacl "^0.14.3"
+
+bcrypt@^3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/bcrypt/-/bcrypt-3.0.6.tgz#f607846df62d27e60d5e795612c4f67d70206eb2"
+  integrity sha512-taA5bCTfXe7FUjKroKky9EXpdhkVvhE5owfxfLYodbrAR1Ul3juLmIQmIQBK4L9a5BuUcE6cqmwT+Da20lF9tg==
+  dependencies:
+    nan "2.13.2"
+    node-pre-gyp "0.12.0"
 
 binary-extensions@^1.0.0:
   version "1.12.0"
@@ -8474,15 +8487,15 @@ mz@^2.4.0:
     object-assign "^4.0.1"
     thenify-all "^1.0.0"
 
+nan@2.13.2, nan@^2.12.1:
+  version "2.13.2"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.13.2.tgz#f51dc7ae66ba7d5d55e1e6d4d8092e802c9aefe7"
+  integrity sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==
+
 nan@^2.10.0, nan@^2.9.2:
   version "2.12.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.12.1.tgz#7b1aa193e9aa86057e3c7bbd0ac448e770925552"
   integrity sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==
-
-nan@^2.12.1:
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.13.2.tgz#f51dc7ae66ba7d5d55e1e6d4d8092e802c9aefe7"
-  integrity sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -8597,10 +8610,10 @@ node-notifier@^5.2.1:
     shellwords "^0.1.1"
     which "^1.3.0"
 
-node-pre-gyp@^0.10.0:
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz#3070040716afdc778747b61b6887bf78880b80fc"
-  integrity sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==
+node-pre-gyp@0.12.0, node-pre-gyp@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz#39ba4bb1439da030295f899e3b520b7785766149"
+  integrity sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==
   dependencies:
     detect-libc "^1.0.2"
     mkdirp "^0.5.1"
@@ -8613,10 +8626,10 @@ node-pre-gyp@^0.10.0:
     semver "^5.3.0"
     tar "^4"
 
-node-pre-gyp@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz#39ba4bb1439da030295f899e3b520b7785766149"
-  integrity sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==
+node-pre-gyp@^0.10.0:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.10.3.tgz#3070040716afdc778747b61b6887bf78880b80fc"
+  integrity sha512-d1xFs+C/IPS8Id0qPTZ4bUT8wWryfR/OzzAFxweG+uLN85oPzyo2Iw6bVlLQ/JOdgNonXLCoRyqDzDWq4iw72A==
   dependencies:
     detect-libc "^1.0.2"
     mkdirp "^0.5.1"


### PR DESCRIPTION
This PR adds support for username/password authentication to the backend. Preserves existing workflows for DA-based accounts.

- Adds a new LocalCredentials model
- Adds a new DeviantartAccount model
- Adds a displayName property to the user model, while removing authentication-related fields
- Improved typing of TX service a bit
- Adds a new password hashing service